### PR TITLE
Add player movement

### DIFF
--- a/FinalQuestino/button_state.h
+++ b/FinalQuestino/button_state.h
@@ -1,0 +1,14 @@
+#if !defined( BUTTON_STATE_H )
+#define BUTTON_STATE_H
+
+#include "common.h"
+
+typedef struct cButtonState_t
+{
+  cBool_t pressed;
+  cBool_t released;
+  cBool_t down;
+}
+cButtonState_t;
+
+#endif // BUTTON_STATE_H

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -15,6 +15,7 @@
 #define TEXT_TILES                44
 
 #define SPRITE_SIZE               16
+#define PACKED_SPRITE_SIZE        8
 #define SPRITE_FRAMES             2
 
 #define PLAYER_MAX_VELOCITY       48

--- a/FinalQuestino/enums.h
+++ b/FinalQuestino/enums.h
@@ -24,7 +24,9 @@ typedef enum cButton_t
   cButton_Left = 0,
   cButton_Up,
   cButton_Right,
-  cButton_Down
+  cButton_Down,
+
+  cButton_Count
 }
 cButton_t;
 

--- a/FinalQuestino/enums.h
+++ b/FinalQuestino/enums.h
@@ -19,4 +19,13 @@ typedef enum cGameState_t
 }
 cGameState_t;
 
+typedef enum cButton_t
+{
+  cButton_Left = 0,
+  cButton_Up,
+  cButton_Right,
+  cButton_Down
+}
+cButton_t;
+
 #endif // ENUMS_H

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -1,16 +1,26 @@
 #include "game.h"
 
+#define COLLISION_PADDING 0.001f
+
+static void cGame_HandleInput( cGame_t* game );
+
 void cGame_Init( cGame_t* game )
 {
   cScreen_Init( &( game->screen ) );
   cScreen_LoadPalette( &( game->screen ), 0 );
   cScreen_Begin( &( game->screen ) );
 
+  cClock_Init( &( game->clock ) );
+  cInputReader_Init( &( game->inputReader ) );
+
   cTileMap_Init( &( game->tileMap ) );
   cTileMap_LoadMap( &( game->tileMap ), 0 );
   cGame_LoadTextBitFields( game );
 
   cPlayer_Init( &( game->player ) );
+  game->player.sprite.direction = cDirection_Down;
+  game->player.position.x = ( TILES_X * TILE_SIZE ) / 2;
+  game->player.position.y = ( TILES_Y * TILE_SIZE ) / 2;
   game->player.hitBoxSize.x = 12;
   game->player.hitBoxSize.y = 12;
   game->player.spriteOffset.x = -2;
@@ -21,12 +31,121 @@ void cGame_Init( cGame_t* game )
 
 void cGame_Tic( cGame_t* game )
 {
-  if ( game->state == cGameState_Init )
+  cInputReader_ReadInput( &( game->inputReader ) );
+  cGame_HandleInput( game );
+
+  switch( game->state )
   {
-    cScreen_DrawTileMap( &( game->screen ), &( game->tileMap ) );
-    cScreen_DrawSprite( &( game->screen ), &( game->player.sprite ), &( game->tileMap ),
-                        game->player.position.x + game->player.spriteOffset.x,
-                        game->player.position.y + game->player.spriteOffset.y );
-    game->state = cGameState_Playing;
+    case cGameState_Init:
+      cScreen_DrawTileMap( &( game->screen ), &( game->tileMap ) );
+      game->state = cGameState_Playing;
+      break;
+    case cGameState_Playing:
+      // TODO: this should go into a physics file, probably
+      game->player.position.x += ( game->player.velocity.x * game->clock.frameSeconds );
+      if ( game->player.position.x < 0 )
+      {
+        game->player.position.x = 0;
+      }
+      else if ( ( game->player.position.x + game->player.hitBoxSize.x ) >= ( TILES_X * TILE_SIZE ) )
+      {
+        game->player.position.x = ( TILES_X * TILE_SIZE ) - game->player.hitBoxSize.x - COLLISION_PADDING;
+      }
+      game->player.position.y += ( game->player.velocity.y * game->clock.frameSeconds );
+      if ( game->player.position.y < 0 )
+      {
+        game->player.position.y = 0;
+      }
+      else if ( ( game->player.position.y + game->player.hitBoxSize.y ) >= ( TILES_Y * TILE_SIZE ) )
+      {
+        game->player.position.y = ( TILES_Y * TILE_SIZE ) - game->player.hitBoxSize.y - COLLISION_PADDING;
+      }
+      game->player.velocity.x = 0;
+      game->player.velocity.y = 0;
+      cScreen_DrawSprite( &( game->screen ), &( game->player.sprite ), &( game->tileMap ),
+                          game->player.position.x + game->player.spriteOffset.x,
+                          game->player.position.y + game->player.spriteOffset.y );
+      break;
+  }
+}
+
+static void cGame_HandleInput( cGame_t* game )
+{
+  cPlayer_t* player = &( game->player );
+  cSprite_t* sprite = &( player->sprite );
+  cBool_t leftIsDown, upIsDown, rightIsDown, downIsDown;
+
+  // TODO: this should go into an input handler file, probably
+  if ( game->state == cGameState_Playing )
+  {
+    leftIsDown = game->inputReader.buttonStates[cButton_Left].down;
+    upIsDown = game->inputReader.buttonStates[cButton_Up].down;
+    rightIsDown = game->inputReader.buttonStates[cButton_Right].down;
+    downIsDown = game->inputReader.buttonStates[cButton_Down].down;
+
+    if ( game->state == cGameState_Playing )
+    {
+      if ( leftIsDown && !rightIsDown )
+      {
+        player->velocity.x = -( player->maxVelocity.x );
+
+        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
+            !( downIsDown && sprite->direction == cDirection_Down ) )
+        {
+          sprite->direction = cDirection_Left;
+        }
+
+        if ( upIsDown || downIsDown )
+        {
+          player->velocity.x *= 0.707;
+        }
+      }
+      else if ( rightIsDown && !leftIsDown )
+      {
+        player->velocity.x = player->maxVelocity.x;
+
+        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
+            !( downIsDown && sprite->direction == cDirection_Down ) )
+        {
+          sprite->direction = cDirection_Right;
+        }
+
+        if ( upIsDown || downIsDown )
+        {
+          player->velocity.x *= 0.707;
+        }
+      }
+
+      if ( upIsDown && !downIsDown )
+      {
+        player->velocity.y = -( player->maxVelocity.y );
+
+        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
+            !( rightIsDown && sprite->direction == cDirection_Right ) )
+        {
+          sprite->direction = cDirection_Up;
+        }
+
+        if ( leftIsDown || rightIsDown )
+        {
+          player->velocity.y *= 0.707;
+        }
+      }
+      else if ( downIsDown && !upIsDown )
+      {
+        player->velocity.y = player->maxVelocity.y;
+
+        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
+            !( rightIsDown && sprite->direction == cDirection_Right ) )
+        {
+          sprite->direction = cDirection_Down;
+        }
+
+        if ( leftIsDown || rightIsDown )
+        {
+          player->velocity.y *= 0.707;
+        }
+      }
+    }
   }
 }

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -19,6 +19,7 @@ void cGame_Init( cGame_t* game )
 
   cPlayer_Init( &( game->player ) );
   game->player.sprite.direction = cDirection_Down;
+  game->player.sprite.frameSeconds = 0.2f;
   game->player.position.x = ( TILES_X * TILE_SIZE ) / 2;
   game->player.position.y = ( TILES_Y * TILE_SIZE ) / 2;
   game->player.hitBoxSize.x = 12;
@@ -43,6 +44,7 @@ void cGame_Tic( cGame_t* game )
     case cGameState_Playing:
       // TODO: this should go into a physics file, probably
       game->player.position.x += ( game->player.velocity.x * game->clock.frameSeconds );
+      game->player.position.y += ( game->player.velocity.y * game->clock.frameSeconds );
       if ( game->player.position.x < 0 )
       {
         game->player.position.x = 0;
@@ -51,7 +53,6 @@ void cGame_Tic( cGame_t* game )
       {
         game->player.position.x = ( TILES_X * TILE_SIZE ) - game->player.hitBoxSize.x - COLLISION_PADDING;
       }
-      game->player.position.y += ( game->player.velocity.y * game->clock.frameSeconds );
       if ( game->player.position.y < 0 )
       {
         game->player.position.y = 0;
@@ -146,6 +147,11 @@ static void cGame_HandleInput( cGame_t* game )
           player->velocity.y *= 0.707;
         }
       }
+    }
+
+    if ( leftIsDown || upIsDown || rightIsDown || downIsDown )
+    {
+      cSprite_Tic( &( player->sprite ), &( game->clock ) );
     }
   }
 }

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -32,6 +32,8 @@ void cGame_Init( cGame_t* game )
 
 void cGame_Tic( cGame_t* game )
 {
+  cVector2f_t prevPlayerPos;
+
   cInputReader_ReadInput( &( game->inputReader ) );
   cGame_HandleInput( game );
 
@@ -43,6 +45,8 @@ void cGame_Tic( cGame_t* game )
       break;
     case cGameState_Playing:
       // TODO: this should go into a physics file, probably
+      prevPlayerPos.x = game->player.position.x;
+      prevPlayerPos.y = game->player.position.y;
       game->player.position.x += ( game->player.velocity.x * game->clock.frameSeconds );
       game->player.position.y += ( game->player.velocity.y * game->clock.frameSeconds );
       if ( game->player.position.x < 0 )
@@ -63,6 +67,13 @@ void cGame_Tic( cGame_t* game )
       }
       game->player.velocity.x = 0;
       game->player.velocity.y = 0;
+      if ( prevPlayerPos.x != game->player.position.x || prevPlayerPos.y != game->player.position.y )
+      {
+        // TODO: this should happen on a new sprite frame as well
+        cScreen_WipeSprite( &( game->screen ), &( game->tileMap ),
+                            prevPlayerPos.x + game->player.spriteOffset.x,
+                            prevPlayerPos.y + game->player.spriteOffset.y );
+      }
       cScreen_DrawSprite( &( game->screen ), &( game->player.sprite ), &( game->tileMap ),
                           game->player.position.x + game->player.spriteOffset.x,
                           game->player.position.y + game->player.spriteOffset.y );

--- a/FinalQuestino/game.h
+++ b/FinalQuestino/game.h
@@ -5,6 +5,7 @@
 #include "screen.h"
 #include "tile_map.h"
 #include "clock.h"
+#include "input_reader.h"
 #include "player.h"
 
 typedef struct cGame_t
@@ -14,6 +15,8 @@ typedef struct cGame_t
   uint8_t textBitFields[TEXT_TILES][8];
 
   cClock_t clock;
+  cInputReader_t inputReader;
+
   cGameState_t state;
   cPlayer_t player;
 }

--- a/FinalQuestino/input_reader.c
+++ b/FinalQuestino/input_reader.c
@@ -1,0 +1,46 @@
+#include "input_reader.h"
+
+// the analog stick ranges from 0 to 1024
+#define ANALOG_THRESHOLD_LOW 200
+#define ANALOG_THRESHOLD_HIGH 824
+
+static void cInputReader_UpdateButtonState( cButtonState_t* buttonState, cBool_t down );
+
+void cInputReader_Init( cInputReader_t* inputReader )
+{
+  uint8_t i;
+
+  for( i = 0; i < (uint8_t)cButton_Count; i++ )
+  {
+    inputReader->buttonStates[i].pressed = cFalse;
+    inputReader->buttonStates[i].released = cFalse;
+    inputReader->buttonStates[i].down = cFalse;
+  }
+}
+
+void cInputReader_ReadInput( cInputReader_t* inputReader )
+{
+  int xValue = analogRead( PIN_ANALOG_X );
+  int yValue = analogRead( PIN_ANALOG_Y );
+
+  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Left ] ), xValue > ANALOG_THRESHOLD_HIGH );
+  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Up ] ), yValue < ANALOG_THRESHOLD_LOW );
+  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Right ] ), xValue < ANALOG_THRESHOLD_LOW );
+  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Down ] ), yValue > ANALOG_THRESHOLD_HIGH );
+}
+
+static void cInputReader_UpdateButtonState( cButtonState_t* buttonState, cBool_t down )
+{
+  if ( down )
+  {
+    buttonState->released = cFalse;
+    buttonState->pressed = buttonState->down ? cFalse : cTrue;
+  }
+  else
+  {
+    buttonState->pressed = cFalse;
+    buttonState->released = buttonState->down ? cTrue : cFalse;
+  }
+
+  buttonState->down = down;
+}

--- a/FinalQuestino/input_reader.h
+++ b/FinalQuestino/input_reader.h
@@ -1,0 +1,28 @@
+#if !defined( INPUT_READER_H )
+#define INPUT_READER_H
+
+#include "common.h"
+#include "button_state.h"
+#include "enums.h"
+
+#define PIN_ANALOG_X A15
+#define PIN_ANALOG_Y A14
+
+typedef struct cInputReader_t
+{
+  cButtonState_t buttonStates[cButton_Count];
+}
+cInputReader_t;
+
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
+void cInputReader_Init( cInputReader_t* inputReader );
+void cInputReader_ReadInput( cInputReader_t* inputReader );
+
+#if defined( __cplusplus )
+}
+#endif
+
+#endif // INPUT_READER_H

--- a/FinalQuestino/screen.c
+++ b/FinalQuestino/screen.c
@@ -348,7 +348,7 @@ void cScreen_DrawSprite( cScreen_t* screen, cSprite_t* sprite, cTileMap_t* map, 
 {
   uint8_t pixelPair, paletteIndex, skipLeft, skipTop, skipRight, skipBottom, curX, curY;
   uint16_t color;
-  uint16_t frameBytes = ( SPRITE_SIZE / 2 ) * SPRITE_SIZE;
+  uint16_t frameBytes = PACKED_SPRITE_SIZE * SPRITE_SIZE;
   uint16_t startByte = ( (uint8_t)( sprite->direction ) * SPRITE_FRAMES * frameBytes ) + ( sprite->currentFrame * frameBytes );
   uint16_t i, pixel, ux, uy;
 
@@ -420,6 +420,86 @@ void cScreen_DrawSprite( cScreen_t* screen, cSprite_t* sprite, cTileMap_t* map, 
         color = cScreen_GetTilePixelColor( screen, map, ux + ( pixel % SPRITE_SIZE ), uy + ( pixel / SPRITE_SIZE ) );
       }
 
+      write16( color >> 8, color );
+    }
+    
+    pixel++;
+    curX++;
+
+    if ( curX >= SPRITE_SIZE )
+    {
+      curX = 0;
+      curY++;
+
+      if ( curY >= SPRITE_SIZE)
+      {
+        curY = 0;
+      }
+    }
+  }
+
+  CS_IDLE;
+}
+
+void cScreen_WipeSprite( cScreen_t* screen, cTileMap_t* map, float x, float y )
+{
+  uint8_t skipLeft, skipTop, skipRight, skipBottom, curX, curY;
+  uint16_t color;
+  uint16_t frameBytes = PACKED_SPRITE_SIZE * SPRITE_SIZE;
+  uint16_t i, pixel, ux, uy;
+
+  if ( x >= ( TILE_SIZE * TILES_X ) || y >= ( TILE_SIZE * TILES_Y ) ||
+       x + SPRITE_SIZE < 0 || y + SPRITE_SIZE < 0 )
+  {
+    return;
+  }
+
+  if ( x < 0 )
+  {
+    ux = 0;
+    skipLeft = (uint8_t)( -( x - NEGATIVE_CLAMP_THETA ) );
+    skipRight = 0;
+  }
+  else
+  {
+    ux = (uint16_t)x;
+    skipLeft = 0;
+    skipRight = ( ux + SPRITE_SIZE ) >= ( TILE_SIZE * TILES_X ) ? TILE_SIZE - ( ( TILE_SIZE * TILES_X ) - ux ) : 0;
+  }
+
+  if ( y < 0 )
+  {
+    uy = 0;
+    skipTop = (uint8_t)( -( y - NEGATIVE_CLAMP_THETA ) );
+    skipBottom = 0;
+  }
+  else
+  {
+    uy = (uint16_t)y;
+    skipTop = 0;
+    skipBottom = ( uy + SPRITE_SIZE ) >= ( TILE_SIZE * TILES_Y ) ? TILE_SIZE - ( ( TILE_SIZE * TILES_Y ) - uy ) : 0;
+  }
+
+  CS_ACTIVE;
+  cScreen_SetAddrWindow( screen, ux, uy, ux + SPRITE_SIZE - skipLeft - skipRight - 1, uy + SPRITE_SIZE - skipTop - skipBottom - 1 );
+  CD_COMMAND;
+  write8( 0x2C );
+  CD_DATA;
+
+  for ( i = 0, pixel = 0, curX = 0, curY = 0; i < frameBytes; i++ )
+  {
+    if ( curX >= skipLeft && curX < ( TILE_SIZE - skipRight ) && curY >= skipTop && curY < ( TILE_SIZE - skipBottom ) )
+    {
+      color = cScreen_GetTilePixelColor( screen, map, ux + ( pixel % SPRITE_SIZE ), uy + ( pixel / SPRITE_SIZE ) );
+      write16( color >> 8, color );
+    }
+    
+    pixel++;
+    curX++;
+
+    if ( curX >= skipLeft && curX < ( TILE_SIZE - skipRight ) && curY >= skipTop && curY < ( TILE_SIZE - skipBottom ) )
+    {
+      color = cScreen_GetTilePixelColor( screen, map, ux + ( pixel % SPRITE_SIZE ), uy + ( pixel / SPRITE_SIZE ) );
       write16( color >> 8, color );
     }
     

--- a/FinalQuestino/screen.h
+++ b/FinalQuestino/screen.h
@@ -124,6 +124,7 @@ void cScreen_DrawTileMap( cScreen_t* screen, cTileMap_t* map );
 void cScreen_DrawText( cScreen_t* screen, const char* text, uint16_t x, uint16_t y,
                        uint16_t backgroundColor, uint16_t foregroundColor, uint8_t* bitFields );
 void cScreen_DrawSprite( cScreen_t* screen, cSprite_t* sprite, cTileMap_t* map, float x, float y );
+void cScreen_WipeSprite( cScreen_t* screen, cTileMap_t* map, float x, float y );
 
 // data_loader.c
 void cScreen_LoadPalette( cScreen_t* screen, uint8_t index );

--- a/FinalQuestino/sprite.c
+++ b/FinalQuestino/sprite.c
@@ -1,4 +1,5 @@
 #include "sprite.h"
+#include "clock.h"
 
 cSprite_Init( cSprite_t* sprite )
 {
@@ -6,9 +7,22 @@ cSprite_Init( cSprite_t* sprite )
   sprite->direction = (cDirection_t)0;
   sprite->currentFrame = 0;
   sprite->elapsedSeconds = 0;
+  sprite->frameSeconds = 1;
 }
 
-cSprite_Tic( cSprite_t* sprite )
+cSprite_Tic( cSprite_t* sprite, cClock_t* clock )
 {
-  // TODO: bring in the clock, and use it to tic the sprite
+  sprite->elapsedSeconds += clock->frameSeconds;
+
+  while ( sprite->elapsedSeconds >= sprite->frameSeconds )
+  {
+    sprite->currentFrame++;
+
+    if ( sprite->currentFrame >= SPRITE_FRAMES )
+    {
+      sprite->currentFrame = 0;
+    }
+
+    sprite->elapsedSeconds -= sprite->frameSeconds;
+  }
 }

--- a/FinalQuestino/sprite.h
+++ b/FinalQuestino/sprite.h
@@ -4,12 +4,15 @@
 #include "common.h"
 #include "enums.h"
 
+typedef struct cClock_t cClock_t;
+
 typedef struct cSprite_t
 {
   uint8_t frameTextures[( SPRITE_SIZE / 2 ) * SPRITE_SIZE * SPRITE_FRAMES * 4];
   cDirection_t direction;
   uint8_t currentFrame;
   float elapsedSeconds;
+  float frameSeconds;
 }
 cSprite_t;
 
@@ -18,7 +21,7 @@ extern "C" {
 #endif
 
 void cSprite_Init( cSprite_t* sprite );
-void cSprite_Tic( cSprite_t* sprite );
+void cSprite_Tic( cSprite_t* sprite, cClock_t* clock );
 
 // data_loader.c
 void cSprite_LoadTextures( cSprite_t* sprite );


### PR DESCRIPTION
## Overview

This PR adds the ability to move the player around with an analog joystick. A lot of this code is copied from Zelduino (as usual).

I think there's still something going on when the player moves along the edges of the map, possibly because we're not wiping the sprite when the frame changes. There's a TODO in there, I guess we'll get to it eventually.