### PR TITLE
Rearrange input functions

### DIFF
--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -2,8 +2,6 @@
 
 #define COLLISION_PADDING 0.001f
 
-static void cGame_HandleInput( cGame_t* game );
-
 void cGame_Init( cGame_t* game )
 {
   cScreen_Init( &( game->screen ) );
@@ -35,7 +33,7 @@ void cGame_Tic( cGame_t* game )
   cVector2f_t prevPlayerPos;
 
   cInput_Read( &( game->input ) );
-  cGame_HandleInput( game );
+  cInput_Handle( game );
 
   switch( game->state )
   {
@@ -78,91 +76,5 @@ void cGame_Tic( cGame_t* game )
                           game->player.position.x + game->player.spriteOffset.x,
                           game->player.position.y + game->player.spriteOffset.y );
       break;
-  }
-}
-
-static void cGame_HandleInput( cGame_t* game )
-{
-  cPlayer_t* player = &( game->player );
-  cSprite_t* sprite = &( player->sprite );
-  cBool_t leftIsDown, upIsDown, rightIsDown, downIsDown;
-
-  // TODO: this should go into an input handler file, probably
-  if ( game->state == cGameState_Playing )
-  {
-    leftIsDown = game->input.buttonStates[cButton_Left].down;
-    upIsDown = game->input.buttonStates[cButton_Up].down;
-    rightIsDown = game->input.buttonStates[cButton_Right].down;
-    downIsDown = game->input.buttonStates[cButton_Down].down;
-
-    if ( game->state == cGameState_Playing )
-    {
-      if ( leftIsDown && !rightIsDown )
-      {
-        player->velocity.x = -( player->maxVelocity.x );
-
-        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
-            !( downIsDown && sprite->direction == cDirection_Down ) )
-        {
-          sprite->direction = cDirection_Left;
-        }
-
-        if ( upIsDown || downIsDown )
-        {
-          player->velocity.x *= 0.707;
-        }
-      }
-      else if ( rightIsDown && !leftIsDown )
-      {
-        player->velocity.x = player->maxVelocity.x;
-
-        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
-            !( downIsDown && sprite->direction == cDirection_Down ) )
-        {
-          sprite->direction = cDirection_Right;
-        }
-
-        if ( upIsDown || downIsDown )
-        {
-          player->velocity.x *= 0.707;
-        }
-      }
-
-      if ( upIsDown && !downIsDown )
-      {
-        player->velocity.y = -( player->maxVelocity.y );
-
-        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
-            !( rightIsDown && sprite->direction == cDirection_Right ) )
-        {
-          sprite->direction = cDirection_Up;
-        }
-
-        if ( leftIsDown || rightIsDown )
-        {
-          player->velocity.y *= 0.707;
-        }
-      }
-      else if ( downIsDown && !upIsDown )
-      {
-        player->velocity.y = player->maxVelocity.y;
-
-        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
-            !( rightIsDown && sprite->direction == cDirection_Right ) )
-        {
-          sprite->direction = cDirection_Down;
-        }
-
-        if ( leftIsDown || rightIsDown )
-        {
-          player->velocity.y *= 0.707;
-        }
-      }
-    }
-
-    if ( leftIsDown || upIsDown || rightIsDown || downIsDown )
-    {
-      cSprite_Tic( &( player->sprite ), &( game->clock ) );
-    }
   }
 }

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -11,7 +11,7 @@ void cGame_Init( cGame_t* game )
   cScreen_Begin( &( game->screen ) );
 
   cClock_Init( &( game->clock ) );
-  cInputReader_Init( &( game->inputReader ) );
+  cInput_Init( &( game->input ) );
 
   cTileMap_Init( &( game->tileMap ) );
   cTileMap_LoadMap( &( game->tileMap ), 0 );
@@ -34,7 +34,7 @@ void cGame_Tic( cGame_t* game )
 {
   cVector2f_t prevPlayerPos;
 
-  cInputReader_ReadInput( &( game->inputReader ) );
+  cInput_Read( &( game->input ) );
   cGame_HandleInput( game );
 
   switch( game->state )
@@ -90,10 +90,10 @@ static void cGame_HandleInput( cGame_t* game )
   // TODO: this should go into an input handler file, probably
   if ( game->state == cGameState_Playing )
   {
-    leftIsDown = game->inputReader.buttonStates[cButton_Left].down;
-    upIsDown = game->inputReader.buttonStates[cButton_Up].down;
-    rightIsDown = game->inputReader.buttonStates[cButton_Right].down;
-    downIsDown = game->inputReader.buttonStates[cButton_Down].down;
+    leftIsDown = game->input.buttonStates[cButton_Left].down;
+    upIsDown = game->input.buttonStates[cButton_Up].down;
+    rightIsDown = game->input.buttonStates[cButton_Right].down;
+    downIsDown = game->input.buttonStates[cButton_Down].down;
 
     if ( game->state == cGameState_Playing )
     {

--- a/FinalQuestino/game.h
+++ b/FinalQuestino/game.h
@@ -15,7 +15,7 @@ typedef struct cGame_t
   uint8_t textBitFields[TEXT_TILES][8];
 
   cClock_t clock;
-  cInputReader_t inputReader;
+  cInput_t input;
 
   cGameState_t state;
   cPlayer_t player;

--- a/FinalQuestino/game.h
+++ b/FinalQuestino/game.h
@@ -5,7 +5,7 @@
 #include "screen.h"
 #include "tile_map.h"
 #include "clock.h"
-#include "input_reader.h"
+#include "input.h"
 #include "player.h"
 
 typedef struct cGame_t

--- a/FinalQuestino/input.c
+++ b/FinalQuestino/input.c
@@ -1,4 +1,4 @@
-#include "input_reader.h"
+#include "input.h"
 
 // the analog stick ranges from 0 to 1024
 #define ANALOG_THRESHOLD_LOW 200

--- a/FinalQuestino/input.c
+++ b/FinalQuestino/input.c
@@ -1,4 +1,4 @@
-#include "input.h"
+#include "game.h"
 
 // the analog stick ranges from 0 to 1024
 #define ANALOG_THRESHOLD_LOW 200
@@ -43,4 +43,89 @@ static void cInput_UpdateButtonState( cButtonState_t* buttonState, cBool_t down 
   }
 
   buttonState->down = down;
+}
+
+void cInput_Handle( cGame_t* game )
+{
+  cPlayer_t* player = &( game->player );
+  cSprite_t* sprite = &( player->sprite );
+  cBool_t leftIsDown, upIsDown, rightIsDown, downIsDown;
+
+  if ( game->state == cGameState_Playing )
+  {
+    leftIsDown = game->input.buttonStates[cButton_Left].down;
+    upIsDown = game->input.buttonStates[cButton_Up].down;
+    rightIsDown = game->input.buttonStates[cButton_Right].down;
+    downIsDown = game->input.buttonStates[cButton_Down].down;
+
+    if ( game->state == cGameState_Playing )
+    {
+      if ( leftIsDown && !rightIsDown )
+      {
+        player->velocity.x = -( player->maxVelocity.x );
+
+        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
+            !( downIsDown && sprite->direction == cDirection_Down ) )
+        {
+          sprite->direction = cDirection_Left;
+        }
+
+        if ( upIsDown || downIsDown )
+        {
+          player->velocity.x *= 0.707;
+        }
+      }
+      else if ( rightIsDown && !leftIsDown )
+      {
+        player->velocity.x = player->maxVelocity.x;
+
+        if ( !( upIsDown && sprite->direction == cDirection_Up ) &&
+            !( downIsDown && sprite->direction == cDirection_Down ) )
+        {
+          sprite->direction = cDirection_Right;
+        }
+
+        if ( upIsDown || downIsDown )
+        {
+          player->velocity.x *= 0.707;
+        }
+      }
+
+      if ( upIsDown && !downIsDown )
+      {
+        player->velocity.y = -( player->maxVelocity.y );
+
+        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
+            !( rightIsDown && sprite->direction == cDirection_Right ) )
+        {
+          sprite->direction = cDirection_Up;
+        }
+
+        if ( leftIsDown || rightIsDown )
+        {
+          player->velocity.y *= 0.707;
+        }
+      }
+      else if ( downIsDown && !upIsDown )
+      {
+        player->velocity.y = player->maxVelocity.y;
+
+        if ( !( leftIsDown && sprite->direction == cDirection_Left ) &&
+            !( rightIsDown && sprite->direction == cDirection_Right ) )
+        {
+          sprite->direction = cDirection_Down;
+        }
+
+        if ( leftIsDown || rightIsDown )
+        {
+          player->velocity.y *= 0.707;
+        }
+      }
+    }
+
+    if ( leftIsDown || upIsDown || rightIsDown || downIsDown )
+    {
+      cSprite_Tic( &( player->sprite ), &( game->clock ) );
+    }
+  }
 }

--- a/FinalQuestino/input.h
+++ b/FinalQuestino/input.h
@@ -8,6 +8,8 @@
 #define PIN_ANALOG_X A15
 #define PIN_ANALOG_Y A14
 
+typedef struct cGame_t cGame_t;
+
 typedef struct cInput_t
 {
   cButtonState_t buttonStates[cButton_Count];
@@ -20,6 +22,7 @@ extern "C" {
 
 void cInput_Init( cInput_t* input );
 void cInput_Read( cInput_t* input );
+void cInput_Handle( cGame_t* game );
 
 #if defined( __cplusplus )
 }

--- a/FinalQuestino/input.h
+++ b/FinalQuestino/input.h
@@ -1,5 +1,5 @@
-#if !defined( INPUT_READER_H )
-#define INPUT_READER_H
+#if !defined( INPUT_H )
+#define INPUT_H
 
 #include "common.h"
 #include "button_state.h"
@@ -8,8 +8,6 @@
 #define PIN_ANALOG_X A15
 #define PIN_ANALOG_Y A14
 
-// MUFFINS: rename this, it's not an input reader. Also rename this whole file to just input.h,
-// and put the handler functions in.
 typedef struct cInput_t
 {
   cButtonState_t buttonStates[cButton_Count];
@@ -27,4 +25,4 @@ void cInput_Read( cInput_t* input );
 }
 #endif
 
-#endif // INPUT_READER_H
+#endif // INPUT_H

--- a/FinalQuestino/input_reader.c
+++ b/FinalQuestino/input_reader.c
@@ -4,32 +4,32 @@
 #define ANALOG_THRESHOLD_LOW 200
 #define ANALOG_THRESHOLD_HIGH 824
 
-static void cInputReader_UpdateButtonState( cButtonState_t* buttonState, cBool_t down );
+static void cInput_UpdateButtonState( cButtonState_t* buttonState, cBool_t down );
 
-void cInputReader_Init( cInputReader_t* inputReader )
+void cInput_Init( cInput_t* input )
 {
   uint8_t i;
 
   for( i = 0; i < (uint8_t)cButton_Count; i++ )
   {
-    inputReader->buttonStates[i].pressed = cFalse;
-    inputReader->buttonStates[i].released = cFalse;
-    inputReader->buttonStates[i].down = cFalse;
+    input->buttonStates[i].pressed = cFalse;
+    input->buttonStates[i].released = cFalse;
+    input->buttonStates[i].down = cFalse;
   }
 }
 
-void cInputReader_ReadInput( cInputReader_t* inputReader )
+void cInput_Read( cInput_t* input )
 {
   int xValue = analogRead( PIN_ANALOG_X );
   int yValue = analogRead( PIN_ANALOG_Y );
 
-  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Left ] ), xValue > ANALOG_THRESHOLD_HIGH );
-  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Up ] ), yValue < ANALOG_THRESHOLD_LOW );
-  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Right ] ), xValue < ANALOG_THRESHOLD_LOW );
-  cInputReader_UpdateButtonState( &( inputReader->buttonStates[cButton_Down ] ), yValue > ANALOG_THRESHOLD_HIGH );
+  cInput_UpdateButtonState( &( input->buttonStates[cButton_Left ] ), xValue > ANALOG_THRESHOLD_HIGH );
+  cInput_UpdateButtonState( &( input->buttonStates[cButton_Up ] ), yValue < ANALOG_THRESHOLD_LOW );
+  cInput_UpdateButtonState( &( input->buttonStates[cButton_Right ] ), xValue < ANALOG_THRESHOLD_LOW );
+  cInput_UpdateButtonState( &( input->buttonStates[cButton_Down ] ), yValue > ANALOG_THRESHOLD_HIGH );
 }
 
-static void cInputReader_UpdateButtonState( cButtonState_t* buttonState, cBool_t down )
+static void cInput_UpdateButtonState( cButtonState_t* buttonState, cBool_t down )
 {
   if ( down )
   {

--- a/FinalQuestino/input_reader.h
+++ b/FinalQuestino/input_reader.h
@@ -8,18 +8,20 @@
 #define PIN_ANALOG_X A15
 #define PIN_ANALOG_Y A14
 
-typedef struct cInputReader_t
+// MUFFINS: rename this, it's not an input reader. Also rename this whole file to just input.h,
+// and put the handler functions in.
+typedef struct cInput_t
 {
   cButtonState_t buttonStates[cButton_Count];
 }
-cInputReader_t;
+cInput_t;
 
 #if defined( __cplusplus )
 extern "C" {
 #endif
 
-void cInputReader_Init( cInputReader_t* inputReader );
-void cInputReader_ReadInput( cInputReader_t* inputReader );
+void cInput_Init( cInput_t* input );
+void cInput_Read( cInput_t* input );
 
 #if defined( __cplusplus )
 }

--- a/FinalQuestino/screen.c
+++ b/FinalQuestino/screen.c
@@ -1,6 +1,8 @@
 #include <string.h>
 
 #include "screen.h"
+#include "sprite.h"
+#include "tile_map.h"
 
 #define NEGATIVE_CLAMP_THETA 0.9999f
 

--- a/FinalQuestino/screen.h
+++ b/FinalQuestino/screen.h
@@ -6,8 +6,6 @@
 // for "Elegoo 2.8 Inch Touch Screen User Manual".
 
 #include "common.h"
-#include "tile_map.h"
-#include "sprite.h"
 
 // possibly useful color macros
 #define	BLACK   0x0000
@@ -87,6 +85,9 @@
 
 #define SCREEN_WIDTH  320
 #define SCREEN_HEIGHT 240
+
+typedef struct cSprite_t cSprite_t;
+typedef struct cTileMap_t cTileMap_t;
 
 typedef struct cScreen_t
 {


### PR DESCRIPTION
## Overview

This does a couple things:

- Changes "input reader" to just "input". I have a tendency to name structs the same way I would name C++ classes, and I've been trying to get away from that. The struct is a data class, it doesn't do anything.
- Moves all the input handling from game.c into input.c. This function still takes in a cGame_t object though, which is kind of a smell, but I'm not worried yet.
- Switches to forward-declared structs in screen.h, this should have been happening already.