### PR TITLE
Detect stepping on tiles

### DIFF
--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -2,6 +2,7 @@
 #define COMMON_H
 
 #include <Arduino.h>
+#include <string.h>
 
 // uncomment to use cSerial_PrintLn
 //#define SERIAL_DEBUG
@@ -19,6 +20,9 @@
 #define SCREENS_Y                 9
 
 #define TILE_PASSABLE_FLAG        0x10
+#define TILE_DAMAGE_FLAG          0x20
+#define TILE_ENCOUNTERABLE_FLAG   0x40
+#define TILE_HIGHRATE_FLAG        0x80
 
 #define TEXT_TILES                44
 

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -46,3 +46,20 @@ void cGame_Tic( cGame_t* game )
       break;
   }
 }
+
+void cGame_SteppedOnTile( cGame_t* game, uint16_t tileIndex )
+{
+  uint8_t tile = game->tileMap.tiles[tileIndex];
+
+  // TODO: if the tile is a portal, swap in the new map and return
+
+  if ( tile & TILE_DAMAGE_FLAG )
+  {
+    // TODO: inflict damage
+  }
+
+  if ( tile & TILE_ENCOUNTERABLE_FLAG )
+  {
+    // TODO: roll for encounter
+  }
+}

--- a/FinalQuestino/game.h
+++ b/FinalQuestino/game.h
@@ -32,6 +32,7 @@ extern "C" {
 
 void cGame_Init( cGame_t* game );
 void cGame_Tic( cGame_t* game );
+void cGame_SteppedOnTile( cGame_t* game, uint16_t tileIndex );
 
 #if defined( __cplusplus )
 }

--- a/FinalQuestino/physics.h
+++ b/FinalQuestino/physics.h
@@ -8,6 +8,7 @@ typedef struct cGame_t cGame_t;
 typedef struct cPhysics_t
 {
   uint8_t spriteFrameCache;
+  uint16_t tileIndexCache;
 }
 cPhysics_t;
 


### PR DESCRIPTION
## Overview

This uses the player's hit box center position to detect whether we've entered a new tile, and takes action if we have. It doesn't do anything at the moment, but eventually we'll want to do things like spawn battles, inflict damage, etc.