### PR TITLE
Added debug flag to turn off encounters

### DIFF
--- a/FinalQuestino/FinalQuestino.ino
+++ b/FinalQuestino/FinalQuestino.ino
@@ -3,7 +3,7 @@
 
 cGame_t g_game;
 
-#if defined( SERIAL_DEBUG )
+#if defined( DEBUG_SERIAL )
 void cSerial_PrintLn( const char* msg )
 {
    Serial.println( msg );
@@ -12,7 +12,7 @@ void cSerial_PrintLn( const char* msg )
 
 void setup()
 {
-#if defined( SERIAL_DEBUG )
+#if defined( DEBUG_SERIAL )
    Serial.begin( 9600 );
 #endif
 

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -7,7 +7,9 @@
 #include <string.h>
 
 // un-comment to use cSerial_PrintLn
-//#define SERIAL_DEBUG
+//#define DEBUG_SERIAL
+// un-comment to turn off encounters
+//#define DEBUG_NOENCOUNTERS
 
 #define GAME_FPS                    30
 
@@ -48,7 +50,7 @@ typedef uint8_t cBool_t;
 extern "C" {
 #endif
 
-#if defined( SERIAL_DEBUG )
+#if defined( DEBUG_SERIAL )
 void cSerial_PrintLn( const char* msg );
 #endif
 

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -202,10 +202,14 @@ static void cGame_DrawMapStatus( cGame_t* game )
 
 void cGame_RollEncounter( cGame_t* game, cBool_t highRate )
 {
+#if defined( DEBUG_NOENCOUNTERS )
+   return;
+#else
    cBool_t spawnEncounter = highRate ? ( cRandom_Percent() <= ENCOUNTER_RATE_HIGH ) : ( cRandom_Percent() <= ENCOUNTER_RATE_NORMAL );
 
    if ( spawnEncounter )
    {
       cGame_ChangeState( game, cGameState_Battle );
    }
+#endif
 }


### PR DESCRIPTION
## Overview

This adds the `DEBUG_NOENCOUNTERS` flag, in case we want to turn off encounters for testing the map.