### PR TITLE
Bugfix: movement speed doesn't work

### DIFF
--- a/FinalQuestino/battle.c
+++ b/FinalQuestino/battle.c
@@ -7,7 +7,7 @@ void Battle_Start( Game_t* game )
 {
    uint8_t enemyIndex;
    uint8_t playerTileX, playerTileY;
-   cVector4u8_t* specialRegion = &( game->tileMap.enemySpecialRegion );
+   Vector4u8_t* specialRegion = &( game->tileMap.enemySpecialRegion );
    char str[32];
 
    if ( Game_OnSpecialEnemyTile( game, SPECIALENEMYID_GREENDRAGON ) )

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -23,92 +23,101 @@
 #define local_persist static
 
 #if defined( VISUAL_STUDIO_DEV )
-#define DELAY_MS( x )                     Sleep( x )
-#define UNUSED_PARAM( x )                 (void)x
+#define DELAY_MS( x )                        Sleep( x )
+#define UNUSED_PARAM( x )                    (void)x
 #else
-#define DELAY_MS( x )                     delay( x )
-#define MICROS( x )                       micros( x )
+#define DELAY_MS( x )                        delay( x )
+#define MICROS( x )                          micros( x )
 #endif
 
 #define MAX_I( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )
 #define MIN_I( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
 
 #if defined( VISUAL_STUDIO_DEV )
-#define GAME_FPS                          60
-#define FRAME_MICROSECONDS                16666
-#define FRAME_SECONDS                     0.01666666f
+#define GAME_FPS                             60
+#define FRAME_MICROSECONDS                   16666
+#define FRAME_SECONDS                        0.01666666f
 #else
-#define GAME_FPS                          30
-#define FRAME_MICROSECONDS                33333
-#define FRAME_SECONDS                     0.03333333f
+#define GAME_FPS                             30
+#define FRAME_MICROSECONDS                   33333
+#define FRAME_SECONDS                        0.03333333f
 #endif
 
-#define MAP_TILE_SIZE                     16
-#define MAP_PACKED_TILE_SIZE              8
-#define MAP_TILES_X                       20
-#define MAP_TILES_Y                       15
-#define MAP_TILE_COUNT                    300
-#define MAP_TILE_TEXTURE_COUNT            16
-#define MAP_TILE_TEXTURE_SIZE_BYTES       128 // 16x16 bit-packed, so 16/2 * 16
-#define MAP_PORTAL_COUNT                  6
-#define MAP_TILE_ENEMY_INDEX_COUNT        4
-#define MAP_SPRITE_COUNT                  16
+#define MAP_TILE_SIZE                        16
+#define MAP_PACKED_TILE_SIZE                 8
+#define MAP_TILES_X                          20
+#define MAP_TILES_Y                          15
+#define MAP_TILE_COUNT                       300
+#define MAP_TILE_TEXTURE_COUNT               16
+#define MAP_TILE_TEXTURE_SIZE_BYTES          128 // 16x16 bit-packed, so 16/2 * 16
+#define MAP_PORTAL_COUNT                     6
+#define MAP_TILE_ENEMY_INDEX_COUNT           4
+#define MAP_SPRITE_COUNT                     16
 
-#define MAP_TILE_FLAG_PASSABLE            0x20
-#define MAP_TILE_FLAG_ENCOUNTERABLE       0x40
+#define GET_TILE_TEXTURE_INDEX( x )          ( ( x ) & 0x1F )
+#define GET_TILE_SPEED( x )                  ( ( ( x ) & 0xC ) >> 2 )
+#define GET_SPRITE_TILE_INDEX( x )           ( ( x ) & 0x1FF )
+#define GET_PORTAL_ORIGIN( x )               ( ( x ) >> 21 )
+#define GET_PORTAL_DEST_TILE_MAP_INDEX( x )  ( ( ( x ) & 0x1FF800 ) >> 11 )
+#define GET_PORTAL_DEST_TILE_INDEX( x )      ( ( x ) & 0x7FF )
+#define GET_ENCOUNTER_RATE( x )              ( ( x ) & 0x3 )
+#define GET_TILE_PASSABLE( x )               ( ( ( x ) & 0x20 ) >> 5 )
+#define GET_TILE_ENCOUNTERABLE( x )          ( ( ( x ) & 0x40 ) >> 6 )
+#define GET_SPRITE_PASSABLE( x )             ( ( ( x ) & 0x2000 ) >> 13 )
+#define GET_SPRITE_INDEX( x )                ( ( ( x ) & 0x1E00 ) >> 9 )
 
-#define TEXT_TILE_COUNT                   73
+#define TEXT_TILE_COUNT                      73
 
-#define SPRITE_SIZE                       16
-#define SPRITE_PACKED_SIZE                8
-#define SPRITE_FRAMES                     2
-#define SPRITE_TEXTURE_SIZE_BYTES         128 // 16x16 bit-packed, so 16/2 * 16
+#define SPRITE_SIZE                          16
+#define SPRITE_PACKED_SIZE                   8
+#define SPRITE_FRAMES                        2
+#define SPRITE_TEXTURE_SIZE_BYTES            128 // 16x16 bit-packed, so 16/2 * 16
 
-#define ENEMY_TILE_TEXTURE_COUNT          78
-#define ENEMY_TILE_TEXTURE_SIZE_BYTES     32 // 8x8 bit-packed, so 8/2 * 8
-#define ENEMY_TILE_SIZE                   8
-#define ENEMY_TILES_X                     10
-#define ENEMY_TILES_Y                     12
-#define ENEMY_TILE_COUNT                  120
+#define ENEMY_TILE_TEXTURE_COUNT             78
+#define ENEMY_TILE_TEXTURE_SIZE_BYTES        32 // 8x8 bit-packed, so 8/2 * 8
+#define ENEMY_TILE_SIZE                      8
+#define ENEMY_TILES_X                        10
+#define ENEMY_TILES_Y                        12
+#define ENEMY_TILE_COUNT                     120
 
-#define SPECIALENEMYID_GREENDRAGON        35
-#define SPECIALENEMYID_GOLEM              27
-#define SPECIALENEMYID_AXEKNIGHT          33
+#define SPECIALENEMYID_GREENDRAGON           35
+#define SPECIALENEMYID_GOLEM                 27
+#define SPECIALENEMYID_AXEKNIGHT             33
 
-#define SPECIALENEMYMAP_GREENDRAGON       64
-#define SPECIALENEMYMAP_GOLEM             53
-#define SPECIALENEMYMAP_AXEKNIGHT         70
+#define SPECIALENEMYMAP_GREENDRAGON          64
+#define SPECIALENEMYMAP_GOLEM                53
+#define SPECIALENEMYMAP_AXEKNIGHT            70
 
-#define SPECIALENEMYTILE_GREENDRAGON      190
-#define SPECIALENEMYTILE_GOLEM            44
-#define SPECIALENEMYTILE_AXEKNIGHT        48
+#define SPECIALENEMYTILE_GREENDRAGON         190
+#define SPECIALENEMYTILE_GOLEM               44
+#define SPECIALENEMYTILE_AXEKNIGHT           48
 
-#define SPECIALENEMYFLAG_GREENDRAGON      0x1
-#define SPECIALENEMYFLAG_GOLEM            0x2
-#define SPECIALENEMYFLAG_AXEKNIGHT        0x4
+#define SPECIALENEMYFLAG_GREENDRAGON         0x1
+#define SPECIALENEMYFLAG_GOLEM               0x2
+#define SPECIALENEMYFLAG_AXEKNIGHT           0x4
 
 #if defined( DEBUG_FASTWALK )
-#define PLAYERVELOCITY_NORMAL             96
-#define PLAYERVELOCITY_SLOW               96
-#define PLAYERVELOCITY_SLOWER             96
-#define PLAYERVELOCITY_CRAWL              96
+#define PLAYERVELOCITY_NORMAL                96
+#define PLAYERVELOCITY_SLOW                  96
+#define PLAYERVELOCITY_SLOWER                96
+#define PLAYERVELOCITY_CRAWL                 96
 #else
-#define PLAYERVELOCITY_NORMAL             64
-#define PLAYERVELOCITY_SLOW               56
-#define PLAYERVELOCITY_SLOWER             40
-#define PLAYERVELOCITY_CRAWL              24
+#define PLAYERVELOCITY_NORMAL                64
+#define PLAYERVELOCITY_SLOW                  56
+#define PLAYERVELOCITY_SLOWER                40
+#define PLAYERVELOCITY_CRAWL                 24
 #endif
-#define PLAYER_HITBOX_SIZE                12
-#define PLAYER_SPRITEOFFSET_X             -2
-#define PLAYER_SPRITEOFFSET_Y             -4
+#define PLAYER_HITBOX_SIZE                   12
+#define PLAYER_SPRITEOFFSET_X                -2
+#define PLAYER_SPRITEOFFSET_Y                -4
 
-#define MENU_CARAT_BLINKRATE              0.3f
+#define MENU_CARAT_BLINKRATE                 0.3f
 
-#define COLLISION_PADDING                 0.001f
+#define COLLISION_PADDING                    0.001f
 
-#define ENCOUNTERRATE_LOW                4
-#define ENCOUNTERRATE_MEDIUM             6
-#define ENCOUNTERRATE_HIGH               8
+#define ENCOUNTERRATE_LOW                    4
+#define ENCOUNTERRATE_MEDIUM                 6
+#define ENCOUNTERRATE_HIGH                   8
 
 typedef uint8_t Bool_t;
 #define True 1

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -137,7 +137,7 @@ void Game_ChangeState( Game_t *game, GameState_t newState )
 
 void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
 {
-   uint8_t i, tileFlagIndex, tileFlags, tileSpeed, tileTextureIndex, encounterRate;
+   uint8_t i, tileTextureIndex, tileFlags, tileSpeed, encounterRate;
    uint8_t tile = game->tileMap.tiles[tileIndex];
    uint16_t newTileIndex, newTileX, newTileY;
 
@@ -145,10 +145,10 @@ void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
 
    for ( i = 0; i < MAP_PORTAL_COUNT; i++ )
    {
-      if ( ( game->tileMap.portals[i] >> 21 ) == tileIndex )
+      if ( GET_PORTAL_ORIGIN( game->tileMap.portals[i] ) == tileIndex )
       {
-         game->tileMapIndex = (uint8_t)( ( game->tileMap.portals[i] >> 11 ) & 0x3FF );
-         newTileIndex = game->tileMap.portals[i] & 0x7FF;
+         game->tileMapIndex = (uint8_t)( GET_PORTAL_DEST_TILE_MAP_INDEX( game->tileMap.portals[i] ) );
+         newTileIndex = GET_PORTAL_DEST_TILE_INDEX( game->tileMap.portals[i] );
          game->tileMap.tileIndexCache = newTileIndex;
          newTileY = newTileIndex / MAP_TILES_X;
          newTileX = newTileIndex - ( newTileY * MAP_TILES_X );
@@ -160,9 +160,9 @@ void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
       }
    }
 
-   tileFlagIndex = tile & 0xF1;
-   tileFlags = game->tileMap.tileTextures[MIN_I( tileFlagIndex, 15 )].flags;
-   tileSpeed = ( tileFlags & 0xC ) >> 2;
+   tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
+   tileFlags = game->tileMap.tileTextures[MIN_I( tileTextureIndex, 15 )].flags;
+   tileSpeed = GET_TILE_SPEED( tileFlags );
 
    switch( tileSpeed )
    {
@@ -183,11 +183,11 @@ void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
    {
       Game_ChangeState( game, GameState_Battle );
    }
-   else if ( tile & MAP_TILE_FLAG_ENCOUNTERABLE )
+   else if ( GET_TILE_ENCOUNTERABLE( tile ) )
    {
-      tileTextureIndex = tile & 0x1F;
+      tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
       tileFlags = game->tileMap.tileTextures[MIN_I( tileTextureIndex, 15 )].flags;
-      encounterRate = tileFlags & 0x3;
+      encounterRate = GET_ENCOUNTER_RATE( tileFlags );
 
       if ( encounterRate > 0 )
       {

--- a/FinalQuestino/physics.c
+++ b/FinalQuestino/physics.c
@@ -1,6 +1,5 @@
 #include "game.h"
 
-internal void Physics_RefreshFromScreenSwap( Game_t* game );
 internal Bool_t Physics_TileHasImpassableSprite( TileMap_t* map, uint16_t tileIndex );
 
 void Physics_Init( Physics_t* physics )
@@ -11,7 +10,7 @@ void Physics_Init( Physics_t* physics )
 
 void Physics_Tic( Game_t* game )
 {
-   cVector2f_t newPos;
+   Vector2f_t newPos;
    Player_t* player = &( game->player );
    uint8_t tileRowStartIndex, tileRowEndIndex, tileColStartIndex, tileColEndIndex, row, col, tile;
    uint16_t tileIndex;
@@ -67,7 +66,7 @@ void Physics_Tic( Game_t* game )
             tileIndex = col + ( row * MAP_TILES_X );
             tile = game->tileMap.tiles[tileIndex];
 
-            if ( !( tile & MAP_TILE_FLAG_PASSABLE ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
+            if ( !GET_TILE_PASSABLE( tile ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
             {
                newPos.x = (float)( ( ( col + 1 ) * MAP_TILE_SIZE ) );
                break;
@@ -84,7 +83,7 @@ void Physics_Tic( Game_t* game )
             tileIndex = col + ( row * MAP_TILES_X );
             tile = game->tileMap.tiles[tileIndex];
 
-            if ( !( tile & MAP_TILE_FLAG_PASSABLE ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
+            if ( !GET_TILE_PASSABLE( tile ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
             {
                newPos.x = ( col * MAP_TILE_SIZE ) - PLAYER_HITBOX_SIZE - COLLISION_PADDING;
                break;
@@ -109,7 +108,7 @@ void Physics_Tic( Game_t* game )
             tileIndex = col + ( row * MAP_TILES_X );
             tile = game->tileMap.tiles[tileIndex];
 
-            if ( !( tile & MAP_TILE_FLAG_PASSABLE ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
+            if ( !GET_TILE_PASSABLE( tile ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
             {
                newPos.y = (float)( ( ( row + 1 ) * MAP_TILE_SIZE ) );
                break;
@@ -126,7 +125,7 @@ void Physics_Tic( Game_t* game )
             tileIndex = col + ( row * MAP_TILES_X );
             tile = game->tileMap.tiles[tileIndex];
 
-            if ( !( tile & MAP_TILE_FLAG_PASSABLE ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
+            if ( !GET_TILE_PASSABLE( tile ) || Physics_TileHasImpassableSprite( &( game->tileMap ), tileIndex ) )
             {
                newPos.y = ( row * MAP_TILE_SIZE ) - PLAYER_HITBOX_SIZE - COLLISION_PADDING;
                break;
@@ -175,9 +174,9 @@ internal Bool_t Physics_TileHasImpassableSprite( TileMap_t* map, uint16_t tileIn
 
    for ( i = 0; i < map->spriteCount; i++ )
    {
-      if ( (uint16_t)( map->spriteData[i] & 0x1FF ) == tileIndex )
+      if ( (uint16_t)( GET_SPRITE_TILE_INDEX( map->spriteData[i] ) ) == tileIndex )
       {
-         return ( ( map->spriteData[i] >> 13 ) & 0x1 ) ? False : True;
+         return GET_SPRITE_PASSABLE( map->spriteData[i] ) ? False : True;
       }
    }
 

--- a/FinalQuestino/player.h
+++ b/FinalQuestino/player.h
@@ -8,13 +8,13 @@
 
 typedef struct Player_t
 {
-   cVector2f_t position;
-   cVector2f_t velocity;
+   Vector2f_t position;
+   Vector2f_t velocity;
    float maxVelocity;
-   cVector2f_t hitBoxSize;
+   Vector2f_t hitBoxSize;
 
    Sprite_t sprite;
-   cVector2f_t spriteOffset;
+   Vector2f_t spriteOffset;
 
    BattleStats_t stats;
    uint16_t experience;

--- a/FinalQuestino/screen.c
+++ b/FinalQuestino/screen.c
@@ -196,7 +196,7 @@ void Screen_DrawTileMap( Game_t* game )
 
             for ( pixelCol = 0; pixelCol < MAP_PACKED_TILE_SIZE; pixelCol++ )
             {
-               tileTextureIndex = tile & 0x1F;
+               tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
                pixelPair = map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels[pixelCol + ( pixelRow * MAP_PACKED_TILE_SIZE )];
 
                paletteIndex = pixelPair >> 4;
@@ -379,7 +379,7 @@ internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y
    uint32_t treasureFlag = TileMap_GetTreasureFlag( game->tileMapIndex, tileIndex );
    Screen_t* screen = &( game->screen );
 
-   tileTextureIndex = tile & 0x1F;
+   tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
    tileTexture = &( map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels );
 
    // check if this pixel is on a treasure that has already been collected
@@ -388,9 +388,9 @@ internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y
       // if there's a sprite on this tile, check that first
       for ( i = 0; i < map->spriteCount; i++ )
       {
-         if ( ( map->spriteData[i] & 0x1FF ) == tileIndex )
+         if ( ( GET_SPRITE_TILE_INDEX( map->spriteData[i] ) ) == tileIndex )
          {
-            spriteIndex = ( map->spriteData[i] >> 9 ) & 0xF;
+            spriteIndex = GET_SPRITE_INDEX( map->spriteData[i] );
 
             if ( spriteIndex != screen->mapSpriteIndexCache )
             {
@@ -432,7 +432,7 @@ void Screen_DrawMapSprites( Game_t* game )
 
    for ( i = 0; i < map->spriteCount; i++ )
    {
-      tileIndex = map->spriteData[i] & 0x1FF;
+      tileIndex = GET_SPRITE_TILE_INDEX( map->spriteData[i] );
       treasureFlag = TileMap_GetTreasureFlag( game->tileMapIndex, tileIndex );
 
       if ( treasureFlag )
@@ -444,7 +444,7 @@ void Screen_DrawMapSprites( Game_t* game )
          }
       }
 
-      spriteIndex = ( map->spriteData[i] >> 9 ) & 0xF;
+      spriteIndex = GET_SPRITE_INDEX( map->spriteData[i] );
       TileMap_LoadSprite( map, spriteIndex );
       game->screen.mapSpriteIndexCache = spriteIndex;
 

--- a/FinalQuestino/tile_map.h
+++ b/FinalQuestino/tile_map.h
@@ -28,14 +28,14 @@ typedef struct TileMap_t
    uint8_t spriteCount;
 
    // low 9 bits are the tile index
-   // middle 4 bits are the sprite texture index
+   // middle 4 bits are the sprite index
    // high 3 bits are flags
    // flag 001: is passable
    // flag 010: reserved
    // flag 100: reserved
    uint16_t spriteData[MAP_SPRITE_COUNT];
 
-   cVector4u8_t enemySpecialRegion;
+   Vector4u8_t enemySpecialRegion;
    uint8_t enemyIndexes[MAP_TILE_ENEMY_INDEX_COUNT];
    uint8_t enemySpecialIndexes[MAP_TILE_ENEMY_INDEX_COUNT];
 }

--- a/FinalQuestino/vector.h
+++ b/FinalQuestino/vector.h
@@ -3,20 +3,20 @@
 
 #include "common.h"
 
-typedef struct cVector2f_t
+typedef struct Vector2f_t
 {
    float x;
    float y;
 }
-cVector2f_t;
+Vector2f_t;
 
-typedef struct cVector4u8_t
+typedef struct Vector4u8_t
 {
    uint8_t x;
    uint8_t y;
    uint8_t w;
    uint8_t h;
 }
-cVector4u8_t;
+Vector4u8_t;
 
 #endif // VECTOR_H

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -31,4 +31,4 @@ GlobalObjects_t;
 
 GlobalObjects_t g_globals;
 
-#endif
+#endif // WIN_COMMON_H

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_pixel_buffer.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_pixel_buffer.h
@@ -14,4 +14,4 @@ WinPixelBuffer_t;
 void WinPixelBuffer_Init( WinPixelBuffer_t* buffer, uint32_t w, uint32_t h );
 void WinPixelBuffer_CleanUp( WinPixelBuffer_t* buffer );
 
-#endif
+#endif // WIN_PIXEL_BUFFER_H

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_random.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_random.c
@@ -5,6 +5,8 @@ void Random_Seed()
 {
    LARGE_INTEGER ticks;
    QueryPerformanceCounter( &ticks );
+
+   // NOTE: normally we'd seed with time( 0 ), but this more closely resembles the kind of seeding we're doing on the Arduino.
    uint32_t micros = (uint32_t)( ( (double)( ticks.QuadPart ) / (double)( g_globals.performanceFrequency.QuadPart ) ) * (uint64_t)1000000 );
    srand( micros & (uint16_t)0xFFFF );
 }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
@@ -98,7 +98,7 @@ void Screen_DrawTileMap( Game_t* game )
 
             for ( pixelCol = 0; pixelCol < MAP_PACKED_TILE_SIZE; pixelCol++ )
             {
-               tileTextureIndex = tile & 0x1F;
+               tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
                pixelPair = map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels[pixelCol + ( pixelRow * MAP_PACKED_TILE_SIZE )];
 
                paletteIndex = pixelPair >> 4;
@@ -253,7 +253,7 @@ void Screen_DrawMapSprites( Game_t* game )
 
    for ( i = 0; i < map->spriteCount; i++ )
    {
-      tileIndex = map->spriteData[i] & 0x1FF;
+      tileIndex = GET_SPRITE_TILE_INDEX( map->spriteData[i] );
       treasureFlag = TileMap_GetTreasureFlag( game->tileMapIndex, tileIndex );
 
       if ( treasureFlag )
@@ -265,7 +265,7 @@ void Screen_DrawMapSprites( Game_t* game )
          }
       }
 
-      spriteIndex = ( map->spriteData[i] >> 9 ) & 0xF;
+      spriteIndex = GET_SPRITE_INDEX( map->spriteData[i] );
       TileMap_LoadSprite( map, spriteIndex );
       game->screen.mapSpriteIndexCache = spriteIndex;
 
@@ -522,7 +522,7 @@ internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y
    uint32_t treasureFlag = TileMap_GetTreasureFlag( game->tileMapIndex, tileIndex );
    Screen_t* screen = &( game->screen );
 
-   tileTextureIndex = tile & 0x1F;
+   tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
 #pragma warning( disable: 4047 )
    tileTexture = &( map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels );
 #pragma warning( default: 4047 )
@@ -533,9 +533,9 @@ internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y
       // if there's a sprite on this tile, check that first
       for ( i = 0; i < map->spriteCount; i++ )
       {
-         if ( ( map->spriteData[i] & 0x1FF ) == tileIndex )
+         if ( ( GET_SPRITE_TILE_INDEX( map->spriteData[i] ) ) == tileIndex )
          {
-            spriteIndex = ( map->spriteData[i] >> 9 ) & 0xF;
+            spriteIndex = GET_SPRITE_INDEX( map->spriteData[i] );
 
             if ( spriteIndex != screen->mapSpriteIndexCache )
             {


### PR DESCRIPTION
## Overview

The player's movement speed is supposed to change based on the terrain, but that stopped working because of a typo I made while fixing all the build warnings (accidentally wrote `0xF1` instead of `0x1F`). To avoid mistakes like these in the future, I put all the bitwise operations into macros, so they're all consolidated to one area.