### PR TITLE
Use program memory for strings

### DIFF
--- a/DataGenerator/DataGenerator/Program.cs
+++ b/DataGenerator/DataGenerator/Program.cs
@@ -627,7 +627,7 @@ string BuildEnemyOutputString()
       }
 
       outputString += "   {\n";
-      outputString += string.Format( "      snprintf( enemy->name, 16, \"{0}\" );\n", enemy.Name );
+      outputString += string.Format( "      snprintf( enemy->name, 16, PSTR( \"{0}\" ) );\n", enemy.Name );
       outputString += string.Format( "      enemy->indefiniteArticle = INDEFINITEARTICLE_{0};\n", enemy.IndefiniteArticle == "A" ? "A" : "AN" );
       outputString += string.Format( "      enemy->stats.HitPoints = {0};\n", enemy.HitPoints );
       outputString += string.Format( "      enemy->stats.MaxHitPoints = {0};\n", enemy.HitPoints );

--- a/FinalQuestino/battle.c
+++ b/FinalQuestino/battle.c
@@ -51,18 +51,18 @@ void Battle_StartHUD( Game_t* game )
 
    // quick stats
    Screen_DrawRect( &( game->screen ), 16, 16, 76, 36, DARKGRAY );
-   snprintf( str, 32, "HP:%u", game->player.stats.HitPoints );
+   snprintf( str, 32, PSTR( "HP:%u" ), game->player.stats.HitPoints );
    Screen_DrawText( &( game->screen ), str, 24, 24, DARKGRAY, WHITE );
-   snprintf( str, 32, "MP:%u", game->player.stats.MagicPoints );
+   snprintf( str, 32, PSTR( "MP:%u" ), game->player.stats.MagicPoints );
    Screen_DrawText( &( game->screen ), str, 24, 36, DARKGRAY, WHITE );
 
    if ( game->battle.enemy.indefiniteArticle == INDEFINITEARTICLE_A )
    {
-      snprintf( str, 32, "A %s approaches!", game->battle.enemy.name );
+      snprintf( str, 32, PSTR( "A %s approaches!" ), game->battle.enemy.name );
    }
    else
    {
-      snprintf( str, 32, "An %s approaches!", game->battle.enemy.name );
+      snprintf( str, 32, PSTR( "An %s approaches!" ), game->battle.enemy.name );
    }
 
    Battle_ShowMessage( game, str );
@@ -75,7 +75,7 @@ void Battle_Attack( Game_t* game )
 {
    Menu_Wipe( game );
    Screen_WipeEnemy( game, 160, 40 );
-   Battle_ShowMessage( game, "Sliced him up real good, you win!" );
+   Battle_ShowMessage( game, PSTR( "Sliced him up real good, you win!" ) );
    game->state = GAMESTATE_BATTLERESULT;
 }
 
@@ -83,7 +83,7 @@ void Battle_Spell( Game_t* game )
 {
    Menu_Wipe( game );
    Screen_WipeEnemy( game, 160, 40 );
-   Battle_ShowMessage( game, "You yell 'ABRA CADABRA!!', which is a death spell. You win!" );
+   Battle_ShowMessage( game, PSTR( "You yell 'ABRA CADABRA!!', which is a death spell. You win!" ) );
    game->state = GAMESTATE_BATTLERESULT;
 }
 
@@ -91,7 +91,7 @@ void Battle_Item( Game_t* game )
 {
    Menu_Wipe( game );
    Screen_WipeEnemy( game, 160, 40 );
-   Battle_ShowMessage( game, "Your spare change hit him in the eye and killed him, you win!" );
+   Battle_ShowMessage( game, PSTR( "Your spare change hit him in the eye and killed him, you win!" ) );
    game->state = GAMESTATE_BATTLERESULT;
 }
 
@@ -99,7 +99,7 @@ void Battle_Flee( Game_t* game )
 {
    Menu_Wipe( game );
    Screen_WipeEnemy( game, 160, 40 );
-   Battle_ShowMessage( game, "You dodged and weaved your way out, nice work!" );
+   Battle_ShowMessage( game, PSTR( "You dodged and weaved your way out, nice work!" ) );
    game->state = GAMESTATE_BATTLERESULT;
 }
 

--- a/FinalQuestino/clock.c
+++ b/FinalQuestino/clock.c
@@ -7,12 +7,12 @@ void Clock_Init( Clock_t* clock )
 
 void Clock_StartFrame( Clock_t* clock )
 {
-   clock->frameStartMicro = MICROS();
+   clock->frameStartMicro = micros();
 }
 
 void Clock_EndFrame( Clock_t* clock )
 {
-   uint32_t frameEndMicro = MICROS();
+   uint32_t frameEndMicro = micros();
    uint32_t elapsedMicro;
 
    if ( frameEndMicro < clock->frameStartMicro )

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -26,9 +26,9 @@
 
 #if defined( VISUAL_STUDIO_DEV )
 #define DELAY_MS( x )                        Sleep( x )
+#define PSTR( x )                            ( x )
 #else
 #define DELAY_MS( x )                        delay( x )
-#define MICROS( x )                          micros( x )
 #endif
 
 #define MAX_I( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )

--- a/FinalQuestino/data_loader.c
+++ b/FinalQuestino/data_loader.c
@@ -20915,7 +20915,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    for ( i = 0; i < 78; i++ ) { for ( j = 0; j < 32; j++ ) { enemy->tileTextures[i][j] = 0; } };
    if ( index == 0 )
    {
-      snprintf( enemy->name, 16, "slime" );
+      snprintf( enemy->name, 16, PSTR( "slime" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21015,7 +21015,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 1 )
    {
-      snprintf( enemy->name, 16, "red slime" );
+      snprintf( enemy->name, 16, PSTR( "red slime" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21110,7 +21110,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 2 )
    {
-      snprintf( enemy->name, 16, "metal slime" );
+      snprintf( enemy->name, 16, PSTR( "metal slime" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21205,7 +21205,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 3 )
    {
-      snprintf( enemy->name, 16, "drakee" );
+      snprintf( enemy->name, 16, PSTR( "drakee" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21360,7 +21360,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 4 )
    {
-      snprintf( enemy->name, 16, "magidrakee" );
+      snprintf( enemy->name, 16, PSTR( "magidrakee" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21510,7 +21510,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 5 )
    {
-      snprintf( enemy->name, 16, "drakeema" );
+      snprintf( enemy->name, 16, PSTR( "drakeema" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21660,7 +21660,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 6 )
    {
-      snprintf( enemy->name, 16, "ghost" );
+      snprintf( enemy->name, 16, PSTR( "ghost" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -21931,7 +21931,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 7 )
    {
-      snprintf( enemy->name, 16, "poltergeist" );
+      snprintf( enemy->name, 16, PSTR( "poltergeist" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -22202,7 +22202,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 8 )
    {
-      snprintf( enemy->name, 16, "specter" );
+      snprintf( enemy->name, 16, PSTR( "specter" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -22474,7 +22474,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 9 )
    {
-      snprintf( enemy->name, 16, "magician" );
+      snprintf( enemy->name, 16, PSTR( "magician" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -22802,7 +22802,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 10 )
    {
-      snprintf( enemy->name, 16, "warlock" );
+      snprintf( enemy->name, 16, PSTR( "warlock" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -23172,7 +23172,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 11 )
    {
-      snprintf( enemy->name, 16, "wizard" );
+      snprintf( enemy->name, 16, PSTR( "wizard" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -23545,7 +23545,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 12 )
    {
-      snprintf( enemy->name, 16, "scorpion" );
+      snprintf( enemy->name, 16, PSTR( "scorpion" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -23815,7 +23815,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 13 )
    {
-      snprintf( enemy->name, 16, "metal scorpion" );
+      snprintf( enemy->name, 16, PSTR( "metal scorpion" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -24085,7 +24085,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 14 )
    {
-      snprintf( enemy->name, 16, "rogue scorpion" );
+      snprintf( enemy->name, 16, PSTR( "rogue scorpion" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -24355,7 +24355,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 15 )
    {
-      snprintf( enemy->name, 16, "druin" );
+      snprintf( enemy->name, 16, PSTR( "druin" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -24682,7 +24682,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 16 )
    {
-      snprintf( enemy->name, 16, "druinlord" );
+      snprintf( enemy->name, 16, PSTR( "druinlord" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -25009,7 +25009,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 17 )
    {
-      snprintf( enemy->name, 16, "droll" );
+      snprintf( enemy->name, 16, PSTR( "droll" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -25438,7 +25438,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 18 )
    {
-      snprintf( enemy->name, 16, "drollmagi" );
+      snprintf( enemy->name, 16, PSTR( "drollmagi" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -25866,7 +25866,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 19 )
    {
-      snprintf( enemy->name, 16, "skeleton" );
+      snprintf( enemy->name, 16, PSTR( "skeleton" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -26252,7 +26252,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 20 )
    {
-      snprintf( enemy->name, 16, "wraith" );
+      snprintf( enemy->name, 16, PSTR( "wraith" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -26636,7 +26636,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 21 )
    {
-      snprintf( enemy->name, 16, "wraith knight" );
+      snprintf( enemy->name, 16, PSTR( "wraith knight" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -27034,7 +27034,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 22 )
    {
-      snprintf( enemy->name, 16, "demon knight" );
+      snprintf( enemy->name, 16, PSTR( "demon knight" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -27420,7 +27420,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 23 )
    {
-      snprintf( enemy->name, 16, "wolf" );
+      snprintf( enemy->name, 16, PSTR( "wolf" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -27885,7 +27885,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 24 )
    {
-      snprintf( enemy->name, 16, "wolflord" );
+      snprintf( enemy->name, 16, PSTR( "wolflord" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -28357,7 +28357,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 25 )
    {
-      snprintf( enemy->name, 16, "werewolf" );
+      snprintf( enemy->name, 16, PSTR( "werewolf" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -28828,7 +28828,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 26 )
    {
-      snprintf( enemy->name, 16, "goldman" );
+      snprintf( enemy->name, 16, PSTR( "goldman" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -29469,7 +29469,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 27 )
    {
-      snprintf( enemy->name, 16, "golem" );
+      snprintf( enemy->name, 16, PSTR( "golem" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -30110,7 +30110,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 28 )
    {
-      snprintf( enemy->name, 16, "stoneman" );
+      snprintf( enemy->name, 16, PSTR( "stoneman" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -30750,7 +30750,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 29 )
    {
-      snprintf( enemy->name, 16, "wyvern" );
+      snprintf( enemy->name, 16, PSTR( "wyvern" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -31141,7 +31141,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 30 )
    {
-      snprintf( enemy->name, 16, "magiwyvern" );
+      snprintf( enemy->name, 16, PSTR( "magiwyvern" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -31532,7 +31532,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 31 )
    {
-      snprintf( enemy->name, 16, "starwyvern" );
+      snprintf( enemy->name, 16, PSTR( "starwyvern" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -31914,7 +31914,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 32 )
    {
-      snprintf( enemy->name, 16, "knight" );
+      snprintf( enemy->name, 16, PSTR( "knight" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -32447,7 +32447,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 33 )
    {
-      snprintf( enemy->name, 16, "axe knight" );
+      snprintf( enemy->name, 16, PSTR( "axe knight" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_AN;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -33057,7 +33057,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 34 )
    {
-      snprintf( enemy->name, 16, "armored knight" );
+      snprintf( enemy->name, 16, PSTR( "armored knight" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_AN;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -33741,7 +33741,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 35 )
    {
-      snprintf( enemy->name, 16, "green dragon" );
+      snprintf( enemy->name, 16, PSTR( "green dragon" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -34282,7 +34282,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 36 )
    {
-      snprintf( enemy->name, 16, "blue dragon" );
+      snprintf( enemy->name, 16, PSTR( "blue dragon" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -34822,7 +34822,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 37 )
    {
-      snprintf( enemy->name, 16, "red dragon" );
+      snprintf( enemy->name, 16, PSTR( "red dragon" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -35362,7 +35362,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 38 )
    {
-      snprintf( enemy->name, 16, "dragonlord wizard" );
+      snprintf( enemy->name, 16, PSTR( "dragonlord wizard" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;
@@ -35801,7 +35801,7 @@ void Enemy_Load( Enemy_t* enemy, uint8_t index )
    }
    else if ( index == 39 )
    {
-      snprintf( enemy->name, 16, "dragonlord dragon" );
+      snprintf( enemy->name, 16, PSTR( "dragonlord dragon" ) );
       enemy->indefiniteArticle = INDEFINITEARTICLE_A;
       enemy->stats.HitPoints = 0;
       enemy->stats.MaxHitPoints = 0;

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -137,13 +137,13 @@ void Game_ShowMapQuickStats( Game_t* game )
    char str[10];
 
    Screen_DrawRect( &( game->screen ), 16, 16, 76, 60, DARKGRAY );
-   snprintf( str, 10, "HP:%u", game->player.stats.HitPoints );
+   snprintf( str, 10, PSTR( "HP:%u" ), game->player.stats.HitPoints );
    Screen_DrawText( &( game->screen ), str, 24, 24, DARKGRAY, WHITE );
-   snprintf( str, 10, "MP:%u", game->player.stats.MagicPoints );
+   snprintf( str, 10, PSTR( "MP:%u" ), game->player.stats.MagicPoints );
    Screen_DrawText( &( game->screen ), str, 24, 36, DARKGRAY, WHITE );
-   snprintf( str, 10, " G:%u", game->player.gold );
+   snprintf( str, 10, PSTR( " G:%u" ), game->player.gold );
    Screen_DrawText( &( game->screen ), str, 24, 48, DARKGRAY, WHITE );
-   snprintf( str, 10, "EX:%u", game->player.experience );
+   snprintf( str, 10, PSTR( "EX:%u" ), game->player.experience );
    Screen_DrawText( &( game->screen ), str, 24, 60, DARKGRAY, WHITE );
 }
 
@@ -214,7 +214,7 @@ void Game_Talk( Game_t* game )
 {
    Game_WipeMapQuickStats( game );
    Menu_Wipe( game );
-   Game_ShowMessage( game, "Nobody's there." );
+   Game_ShowMessage( game, PSTR( "Nobody's there." ) );
    game->state = GAMESTATE_MAPMESSAGE;
 }
 
@@ -228,19 +228,19 @@ void Game_Status( Game_t* game )
    
    Screen_DrawRect( &( game->screen ), 16, 16, 112, 96, DARKGRAY );
 
-   snprintf( str, 14, "Lvl: %u", Player_GetLevel( player ) );
+   snprintf( str, 14, PSTR( "Lvl: %u" ), Player_GetLevel( player ) );
    Screen_DrawText( &( game->screen ), str, 24, 24, DARKGRAY, WHITE );
-   snprintf( str, 14, " HP: %u/%u", player->stats.HitPoints, player->stats.MaxHitPoints );
+   snprintf( str, 14, PSTR( " HP: %u/%u" ), player->stats.HitPoints, player->stats.MaxHitPoints );
    Screen_DrawText( &( game->screen ), str, 24, 36, DARKGRAY, WHITE );
-   snprintf( str, 14, " MP: %u/%u", player->stats.MagicPoints, player->stats.MaxMagicPoints );
+   snprintf( str, 14, PSTR( " MP: %u/%u" ), player->stats.MagicPoints, player->stats.MaxMagicPoints );
    Screen_DrawText( &( game->screen ), str, 24, 48, DARKGRAY, WHITE );
-   snprintf( str, 14, "Atk: %u", player->stats.AttackPower );
+   snprintf( str, 14, PSTR( "Atk: %u" ), player->stats.AttackPower );
    Screen_DrawText( &( game->screen ), str, 24, 60, DARKGRAY, WHITE );
-   snprintf( str, 14, "Def: %u", player->stats.DefensePower );
+   snprintf( str, 14, PSTR( "Def: %u" ), player->stats.DefensePower );
    Screen_DrawText( &( game->screen ), str, 24, 72, DARKGRAY, WHITE );
-   snprintf( str, 14, "Agl: %u", player->stats.Agility );
+   snprintf( str, 14, PSTR( "Agl: %u" ), player->stats.Agility );
    Screen_DrawText( &( game->screen ), str, 24, 84, DARKGRAY, WHITE );
-   snprintf( str, 14, "Exp: %u", player->experience );
+   snprintf( str, 14, PSTR( "Exp: %u" ), player->experience );
    Screen_DrawText( &( game->screen ), str, 24, 96, DARKGRAY, WHITE );
 
    game->state = GAMESTATE_MAPSTATUS;
@@ -258,7 +258,7 @@ void Game_Search( Game_t* game )
    {
       if ( Game_CollectTreasure( game, treasureFlag ) )
       {
-         Game_ShowMessage( game, "Time to quit your day job!" );
+         Game_ShowMessage( game, PSTR( "Time to quit your day job!" ) );
 
          y = ( uint8_t )( game->tileMap.tileIndexCache / MAP_TILES_X );
          x = ( uint8_t )( game->tileMap.tileIndexCache - ( y * MAP_TILES_X ) );
@@ -267,12 +267,12 @@ void Game_Search( Game_t* game )
       }
       else
       {
-         Game_ShowMessage( game, "Can't carry any more of these." );
+         Game_ShowMessage( game, PSTR( "Can't carry any more of these." ) );
       }
    }
    else
    {
-      Game_ShowMessage( game, "You didn't find anything." );
+      Game_ShowMessage( game, PSTR( "You didn't find anything." ) );
    }
 
    game->state = GAMESTATE_MAPMESSAGE;
@@ -289,7 +289,7 @@ void Game_MapSpell( Game_t* game )
 {
    Game_WipeMapQuickStats( game );
    Menu_Wipe( game );
-   Game_ShowMessage( game, "You don't know any spells." );
+   Game_ShowMessage( game, PSTR( "You don't know any spells." ) );
    game->state = GAMESTATE_MAPMESSAGE;
 }
 
@@ -297,6 +297,6 @@ void Game_MapItem( Game_t* game )
 {
    Game_WipeMapQuickStats( game );
    Menu_Wipe( game );
-   Game_ShowMessage( game, "You don't have any items." );
+   Game_ShowMessage( game, PSTR( "You don't have any items." ) );
    game->state = GAMESTATE_MAPMESSAGE;
 }

--- a/FinalQuestino/menu.c
+++ b/FinalQuestino/menu.c
@@ -29,18 +29,18 @@ void Menu_Draw( Game_t* game )
    {
       case MENUINDEX_MAP:
          Screen_DrawRect( &( game->screen ), 16, 88, 76, 88, DARKGRAY );
-         Screen_DrawText( &( game->screen ), "TALK", 32, 96, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "STATUS", 32, 112, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "SEARCH", 32, 128, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "SPELL", 32, 144, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "ITEM", 32, 160, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "TALK" ), 32, 96, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "STATUS" ), 32, 112, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "SEARCH" ), 32, 128, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "SPELL" ), 32, 144, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "ITEM" ), 32, 160, DARKGRAY, WHITE );
          break;
       case MENUINDEX_BATTLEMAIN:
          Screen_DrawRect( &( game->screen ), 16, 152, 76, 72, DARKGRAY );
-         Screen_DrawText( &( game->screen ), "ATTACK", 32, 160, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "SPELL", 32, 176, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "ITEM", 32, 192, DARKGRAY, WHITE );
-         Screen_DrawText( &( game->screen ), "FLEE", 32, 208, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "ATTACK" ), 32, 160, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "SPELL" ), 32, 176, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "ITEM" ), 32, 192, DARKGRAY, WHITE );
+         Screen_DrawText( &( game->screen ), PSTR( "FLEE" ), 32, 208, DARKGRAY, WHITE );
    }
 
    Menu_DrawCarat( game );


### PR DESCRIPTION
## Overview

When looking for ways to reduce memory usage, I found out that passing strings as function parameters uses a LOT of memory for some reason. The Arduino forums suggested using the `F( str )` macro, which pushes the string into program memory instead. Turns out `F` is a C++ macro that does some kind of cast (const char* to wstring, I think?), but if you trace it all the way down, it eventually uses the `PSTR()` macro in `pgmspace.h`:

`# define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))`

If we wrap every string in the entire project with this, it reduces memory usage by a whopping 10%! It's a really good thing too, because this game is gonna have a lot of strings.