### PR TITLE
Update special enemy flags after killing them

### DIFF
--- a/FinalQuestino/battle.c
+++ b/FinalQuestino/battle.c
@@ -294,7 +294,6 @@ void Battle_ExecuteAttack( Game_t* game )
 
    if ( enemy->stats.HitPoints == 0 )
    {
-      // TODO: if this was a special enemy, mark it as defeated so we don't encounter it again
       Screen_WipeEnemy( game, 160, 40 );
       SPRINTF_P( msg,
                  PSTR( "The %s's hit points have been reduced by %u. You have defeated the %s!" ),
@@ -302,6 +301,20 @@ void Battle_ExecuteAttack( Game_t* game )
                  payload,
                  enemy->name );
       Battle_ShowMessage( game, msg );
+
+      if ( Game_OnSpecialEnemyTile( game, SPECIALENEMYID_GREENDRAGON ) )
+      {
+         game->specialEnemyFlags ^= SPECIALENEMYFLAG_GREENDRAGON;
+      }
+      else if ( Game_OnSpecialEnemyTile( game, SPECIALENEMYID_GOLEM ) )
+      {
+         game->specialEnemyFlags ^= SPECIALENEMYFLAG_GOLEM;
+      }
+      else if ( Game_OnSpecialEnemyTile( game, SPECIALENEMYID_AXEKNIGHT ) )
+      {
+         game->specialEnemyFlags ^= SPECIALENEMYFLAG_AXEKNIGHT;
+      }
+
       game->state = GAMESTATE_BATTLERESULT;
    }
    else


### PR DESCRIPTION
## Overview

This is a quick PR to make sure that if you manage to kill a special enemy, its flag gets set to zero so you don't encounter it again when stepping on the tile.