### PR TITLE
Debug options for Windows development

### DIFF
--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -169,6 +169,7 @@ typedef struct DebugFlags_t
    Bool_t encounterRates;
    Bool_t fastWalk;
    Bool_t noEncounters;
+   Bool_t noClip;
 }
 DebugFlags_t;
 

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -13,9 +13,9 @@
 // un-comment to use Serial_PrintLn
 //#define DEBUG_SERIAL
 // un-comment to turn off encounters when the B button is pressed
-//#define DEBUG_NOENCOUNTERSONB
+#define DEBUG_NOENCOUNTERSONB
 // un-comment to turn on fast walk mode
-//#define DEBUG_FASTWALK
+#define DEBUG_FASTWALK
 
 // not really necessary, but makes things easier to distinguish
 #define internal static

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -10,12 +10,14 @@
 #include <limits.h>
 #include <string.h>
 
+// Arduino debug flags
+
 // un-comment to use Serial_PrintLn
 //#define DEBUG_SERIAL
 // un-comment to turn off encounters when the B button is pressed
-#define DEBUG_NOENCOUNTERSONB
+//#define DEBUG_NOENCOUNTERSONB
 // un-comment to turn on fast walk mode
-#define DEBUG_FASTWALK
+//#define DEBUG_FASTWALK
 
 // not really necessary, but makes things easier to distinguish
 #define internal static
@@ -159,6 +161,18 @@ typedef uint8_t Bool_t;
 #define True 1
 #define False 0
 #define TOGGLE_BOOL( b ) b = b ? False : True
+
+#if defined( VISUAL_STUDIO_DEV )
+typedef struct DebugFlags_t
+{
+   Bool_t passableTiles;
+   Bool_t encounterRates;
+   Bool_t fastWalk;
+}
+DebugFlags_t;
+
+DebugFlags_t g_debugFlags;
+#endif
 
 #if defined( DEBUG_SERIAL )
 

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -168,6 +168,7 @@ typedef struct DebugFlags_t
    Bool_t passableTiles;
    Bool_t encounterRates;
    Bool_t fastWalk;
+   Bool_t noEncounters;
 }
 DebugFlags_t;
 

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -97,6 +97,13 @@ void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
       default: game->player.maxVelocity = PLAYERVELOCITY_NORMAL; break;
    }
 
+#if defined( VISUAL_STUDIO_DEV )
+   if ( g_debugFlags.fastWalk )
+   {
+      game->player.maxVelocity = 96;
+   }
+#endif
+
 #if defined( DEBUG_NOENCOUNTERSONB )
    if ( game->input.buttonStates[BUTTON_B].down )
    {

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -102,6 +102,10 @@ void Game_SteppedOnTile( Game_t* game, uint16_t tileIndex )
    {
       game->player.maxVelocity = 96;
    }
+   if ( g_debugFlags.noEncounters )
+   {
+      return;
+   }
 #endif
 
 #if defined( DEBUG_NOENCOUNTERSONB )
@@ -167,6 +171,13 @@ void Game_WipeMapStatus( Game_t* game )
 internal void Game_RollEncounter( Game_t* game, uint8_t encounterRate )
 {
    Bool_t spawnEncounter;
+
+#if defined( VISUAL_STUDIO_DEV )
+   if ( g_debugFlags.noEncounters )
+   {
+      return;
+   }
+#endif
 
 #if defined( DEBUG_NOENCOUNTERSONB )
    if ( game->input.buttonStates[BUTTON_B].down )

--- a/FinalQuestino/physics.c
+++ b/FinalQuestino/physics.c
@@ -50,6 +50,11 @@ void Physics_Tic( Game_t* game )
       return;
    }
 
+#if defined( VISUAL_STUDIO_DEV )
+   if ( !g_debugFlags.noClip )
+   {
+#endif
+
    // clip to unpassable horizontal tiles
    if ( newPos.x != player->position.x )
    {
@@ -133,6 +138,10 @@ void Physics_Tic( Game_t* game )
          }
       }
    }
+
+#if defined( VISUAL_STUDIO_DEV )
+   }
+#endif
 
    posChanged = newPos.x != player->position.x || newPos.y != player->position.y;
 

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -21,6 +21,7 @@
 #define VK_DEBUG_ENCOUNTERRATES     0x32     // 2
 #define VK_DEBUG_FASTWALK           0x33     // 3
 #define VK_DEBUG_NOENCOUNTERS       0x34     // 4
+#define VK_DEBUG_NOCLIP             0x35     // 5
 
 typedef struct GlobalObjects_t
 {

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -14,8 +14,10 @@
 #include "win_pixel_buffer.h"
 #include "vector.h"
 
-#define STRING_SIZE_DEFAULT   1024
-#define GRAPHICS_SCALE        2.0f
+#define STRING_SIZE_DEFAULT         1024
+#define GRAPHICS_SCALE              2.0f
+
+#define VK_DEBUG_TILEPASSABILITY    0x31     // 1
 
 typedef struct GlobalObjects_t
 {
@@ -38,6 +40,8 @@ typedef struct GlobalObjects_t
    Bool_t hasPaddedBattleAttackEnd;
 
    float animationSecondsElapsed;
+
+   Bool_t debugShowTilePassability;
 }
 GlobalObjects_t;
 

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -18,6 +18,10 @@
 #define GRAPHICS_SCALE              2.0f
 
 #define VK_DEBUG_TILEPASSABILITY    0x31     // 1
+#define VK_DEBUG_ENCOUNTERRATE      0x32     // 2
+
+#define DEBUGMASK_TILEPASSABILITY   0x1
+#define DEBUGMASK_ENCOUNTERRATE     0x2
 
 typedef struct GlobalObjects_t
 {
@@ -41,7 +45,7 @@ typedef struct GlobalObjects_t
 
    float animationSecondsElapsed;
 
-   Bool_t debugShowTilePassability;
+   uint32_t debugFlags;
 }
 GlobalObjects_t;
 

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -22,6 +22,7 @@
 #define VK_DEBUG_FASTWALK           0x33     // 3
 #define VK_DEBUG_NOENCOUNTERS       0x34     // 4
 #define VK_DEBUG_NOCLIP             0x35     // 5
+#define VK_DEBUG_CLEARFLAGS         0x30     // 0
 
 typedef struct GlobalObjects_t
 {

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -20,6 +20,7 @@
 #define VK_DEBUG_PASSABLETILES      0x31     // 1
 #define VK_DEBUG_ENCOUNTERRATES     0x32     // 2
 #define VK_DEBUG_FASTWALK           0x33     // 3
+#define VK_DEBUG_NOENCOUNTERS       0x34     // 4
 
 typedef struct GlobalObjects_t
 {

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -17,11 +17,9 @@
 #define STRING_SIZE_DEFAULT         1024
 #define GRAPHICS_SCALE              2.0f
 
-#define VK_DEBUG_TILEPASSABILITY    0x31     // 1
-#define VK_DEBUG_ENCOUNTERRATE      0x32     // 2
-
-#define DEBUGMASK_TILEPASSABILITY   0x1
-#define DEBUGMASK_ENCOUNTERRATE     0x2
+#define VK_DEBUG_PASSABLETILES      0x31     // 1
+#define VK_DEBUG_ENCOUNTERRATES     0x32     // 2
+#define VK_DEBUG_FASTWALK           0x33     // 3
 
 typedef struct GlobalObjects_t
 {
@@ -44,8 +42,6 @@ typedef struct GlobalObjects_t
    Bool_t hasPaddedBattleAttackEnd;
 
    float animationSecondsElapsed;
-
-   uint32_t debugFlags;
 }
 GlobalObjects_t;
 

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -90,7 +90,9 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    g_globals.bmpInfo.bmiHeader.biBitCount = 32;
    g_globals.bmpInfo.bmiHeader.biCompression = BI_RGB;
 
-   g_globals.debugFlags = 0;
+   g_debugFlags.passableTiles = False;
+   g_debugFlags.encounterRates = False;
+   g_debugFlags.fastWalk = False;
 
    InitButtonMap();
    InitBattleStartRects();
@@ -284,13 +286,18 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
 
          switch ( keyCode )
          {
-            case VK_DEBUG_TILEPASSABILITY:
-               g_globals.debugFlags = ( g_globals.debugFlags & DEBUGMASK_TILEPASSABILITY ) ? 0 : DEBUGMASK_TILEPASSABILITY;
+            case VK_DEBUG_PASSABLETILES:
+               g_debugFlags.encounterRates = False;
+               TOGGLE_BOOL( g_debugFlags.passableTiles );
                Game_RefreshMap( &( g_globals.game ) );
                break;
-            case VK_DEBUG_ENCOUNTERRATE:
-               g_globals.debugFlags = ( g_globals.debugFlags & DEBUGMASK_ENCOUNTERRATE ) ? 0 : DEBUGMASK_ENCOUNTERRATE;
+            case VK_DEBUG_ENCOUNTERRATES:
+               g_debugFlags.passableTiles = False;
+               TOGGLE_BOOL( g_debugFlags.encounterRates );
                Game_RefreshMap( &( g_globals.game ) );
+               break;
+            case VK_DEBUG_FASTWALK:
+               TOGGLE_BOOL( g_debugFlags.fastWalk );
                break;
          }
       }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -94,6 +94,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    g_debugFlags.encounterRates = False;
    g_debugFlags.fastWalk = False;
    g_debugFlags.noEncounters = False;
+   g_debugFlags.noClip = False;
 
    InitButtonMap();
    InitBattleStartRects();
@@ -302,6 +303,9 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                break;
             case VK_DEBUG_NOENCOUNTERS:
                TOGGLE_BOOL( g_debugFlags.noEncounters );
+               break;
+            case VK_DEBUG_NOCLIP:
+               TOGGLE_BOOL( g_debugFlags.noClip );
                break;
          }
       }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -90,7 +90,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    g_globals.bmpInfo.bmiHeader.biBitCount = 32;
    g_globals.bmpInfo.bmiHeader.biCompression = BI_RGB;
 
-   g_globals.debugShowTilePassability = False;
+   g_globals.debugFlags = 0;
 
    InitButtonMap();
    InitBattleStartRects();
@@ -282,10 +282,16 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
             }
          }
 
-         if ( keyCode == VK_DEBUG_TILEPASSABILITY && g_globals.game.state == GAMESTATE_MAP )
+         switch ( keyCode )
          {
-            TOGGLE_BOOL( g_globals.debugShowTilePassability );
-            Game_RefreshMap( &( g_globals.game ) );
+            case VK_DEBUG_TILEPASSABILITY:
+               g_globals.debugFlags = ( g_globals.debugFlags & DEBUGMASK_TILEPASSABILITY ) ? 0 : DEBUGMASK_TILEPASSABILITY;
+               Game_RefreshMap( &( g_globals.game ) );
+               break;
+            case VK_DEBUG_ENCOUNTERRATE:
+               g_globals.debugFlags = ( g_globals.debugFlags & DEBUGMASK_ENCOUNTERRATE ) ? 0 : DEBUGMASK_ENCOUNTERRATE;
+               Game_RefreshMap( &( g_globals.game ) );
+               break;
          }
       }
       else

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -13,6 +13,8 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags );
 internal void RenderScreen();
 internal void BattleStartAnimationTic();
 internal void BattleAttackAnimationTic();
+internal BOOL WriteScreenBufferToFile( const char* filePath );
+internal void WriteAllTileMapsToBitmapFiles();
 
 int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow )
 {
@@ -289,14 +291,20 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
          switch ( keyCode )
          {
             case VK_DEBUG_PASSABLETILES:
-               g_debugFlags.encounterRates = False;
-               TOGGLE_BOOL( g_debugFlags.passableTiles );
-               Game_RefreshMap( &( g_globals.game ) );
+               if ( g_globals.game.state == GAMESTATE_MAP )
+               {
+                  g_debugFlags.encounterRates = False;
+                  TOGGLE_BOOL( g_debugFlags.passableTiles );
+                  Game_RefreshMap( &( g_globals.game ) );
+               }
                break;
             case VK_DEBUG_ENCOUNTERRATES:
-               g_debugFlags.passableTiles = False;
-               TOGGLE_BOOL( g_debugFlags.encounterRates );
-               Game_RefreshMap( &( g_globals.game ) );
+               if ( g_globals.game.state == GAMESTATE_MAP )
+               {
+                  g_debugFlags.passableTiles = False;
+                  TOGGLE_BOOL( g_debugFlags.encounterRates );
+                  Game_RefreshMap( &( g_globals.game ) );
+               }
                break;
             case VK_DEBUG_FASTWALK:
                TOGGLE_BOOL( g_debugFlags.fastWalk );
@@ -306,6 +314,17 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                break;
             case VK_DEBUG_NOCLIP:
                TOGGLE_BOOL( g_debugFlags.noClip );
+               break;
+            case VK_DEBUG_CLEARFLAGS:
+               if ( g_globals.game.state == GAMESTATE_MAP )
+               {
+                  g_debugFlags.passableTiles = False;
+                  g_debugFlags.encounterRates = False;
+                  Game_RefreshMap( &( g_globals.game ) );
+               }
+               g_debugFlags.fastWalk = False;
+               g_debugFlags.noEncounters = False;
+               g_debugFlags.noClip = False;
                break;
          }
       }
@@ -440,5 +459,147 @@ internal void BattleAttackAnimationTic()
    {
       g_globals.isAnimatingBattleAttack = False;
       Battle_ExecuteAttack( &( g_globals.game ) );
+   }
+}
+
+// copied from Stack Overflow, of course
+internal BOOL WriteScreenBufferToFile( const char* filePath )
+{
+   HBITMAP hBitmap;
+   HDC hDC;
+   int iBits;
+   WORD wBitCount;
+   DWORD dwPaletteSize = 0, dwBmBitsSize = 0, dwDIBSize = 0, dwWritten = 0;
+   BITMAP Bitmap0;
+   BITMAPFILEHEADER bmfHdr;
+   BITMAPINFOHEADER bi;
+   LPBITMAPINFOHEADER lpbi;
+   HANDLE fh, hDib, hPal, hOldPal2 = NULL;
+
+   hBitmap = CreateBitmap( g_globals.screenBuffer.w, g_globals.screenBuffer.h, 1, 32, (LPVOID)( g_globals.screenBuffer.memory ) );
+
+   if ( !hBitmap )
+   {
+      return FALSE;
+   }
+
+   hDC = CreateDC( TEXT( "DISPLAY" ), NULL, NULL, NULL );
+   iBits = GetDeviceCaps( hDC, BITSPIXEL ) * GetDeviceCaps( hDC, PLANES );
+   DeleteDC( hDC );
+
+   if ( iBits <= 1 )
+   {
+      wBitCount = 1;
+   }
+   else if ( iBits <= 4 )
+   {
+      wBitCount = 4;
+   }
+   else if ( iBits <= 8 )
+   {
+      wBitCount = 8;
+   }
+   else
+   {
+      wBitCount = 24;
+   }
+
+   GetObject( hBitmap, sizeof( Bitmap0 ), (LPSTR)( &Bitmap0 ) );
+
+   bi.biSize = sizeof( BITMAPINFOHEADER );
+   bi.biWidth = Bitmap0.bmWidth;
+   bi.biHeight = -Bitmap0.bmHeight;
+   bi.biPlanes = 1;
+   bi.biBitCount = wBitCount;
+   bi.biCompression = BI_RGB;
+   bi.biSizeImage = 0;
+   bi.biXPelsPerMeter = 0;
+   bi.biYPelsPerMeter = 0;
+   bi.biClrImportant = 0;
+   bi.biClrUsed = 256;
+
+   dwBmBitsSize = ( ( ( Bitmap0.bmWidth * wBitCount ) + 31 ) & ~31 ) / 8 * Bitmap0.bmHeight;
+
+   hDib = GlobalAlloc( GHND, dwBmBitsSize + dwPaletteSize + sizeof( BITMAPINFOHEADER ) );
+
+   if ( !hDib )
+   {
+      return FALSE;
+   }
+
+   lpbi = (LPBITMAPINFOHEADER)GlobalLock( hDib );
+
+   if ( !lpbi )
+   {
+      return FALSE;
+   }
+
+   *lpbi = bi;
+   hPal = GetStockObject( DEFAULT_PALETTE );
+
+   if ( hPal )
+   {
+      hDC = GetDC( NULL );
+      hOldPal2 = SelectPalette( hDC, (HPALETTE)hPal, FALSE );
+      RealizePalette( hDC );
+   }
+
+   GetDIBits( hDC,
+              hBitmap,
+              0,
+              (UINT)Bitmap0.bmHeight,
+              (LPSTR)lpbi + sizeof( BITMAPINFOHEADER ) + dwPaletteSize,
+              (BITMAPINFO*)lpbi,
+              DIB_RGB_COLORS );
+
+   if ( hOldPal2 )
+   {
+      SelectPalette( hDC, (HPALETTE)hOldPal2, TRUE );
+      RealizePalette( hDC );
+      ReleaseDC( NULL, hDC );
+   }
+
+   fh = CreateFileA( filePath, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL );
+
+   if ( fh == INVALID_HANDLE_VALUE )
+   {
+      return FALSE;
+   }
+
+   bmfHdr.bfType = 0x4D42; // "BM"
+   dwDIBSize = sizeof( BITMAPFILEHEADER ) + sizeof( BITMAPINFOHEADER ) + dwPaletteSize + dwBmBitsSize;
+   bmfHdr.bfSize = dwDIBSize;
+   bmfHdr.bfReserved1 = 0;
+   bmfHdr.bfReserved2 = 0;
+   bmfHdr.bfOffBits = (DWORD)sizeof( BITMAPFILEHEADER ) + (DWORD)sizeof( BITMAPINFOHEADER ) + dwPaletteSize;
+
+   WriteFile( fh, (LPSTR)( &bmfHdr ), sizeof( BITMAPFILEHEADER ), &dwWritten, NULL );
+
+   WriteFile( fh, (LPSTR)lpbi, dwDIBSize, &dwWritten, NULL );
+   GlobalUnlock( hDib );
+   GlobalFree( hDib );
+   CloseHandle( fh );
+   return TRUE;
+}
+
+// this function can be really useful for getting a bird's eye view of the entire map,
+// it just spits out a bunch of bitmap files for every tile map in the game.
+internal void WriteAllTileMapsToBitmapFiles()
+{
+   uint8_t i;
+   Game_t* game = &( g_globals.game );
+   char filePath[256];
+
+   for ( i = 0; i < 92; i++ )
+   {
+      TileMap_LoadTileMap( &( game->tileMap ), i );
+      Screen_DrawTileMap( game );
+
+      snprintf( filePath, 256, "C:\\YourPathGoesHere\\tilemap_%u.bmp", i );
+
+      if ( !WriteScreenBufferToFile( filePath ) )
+      {
+         FatalError( "Could not write screen buffer to file." );
+      }
    }
 }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -326,6 +326,7 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
 internal void RenderScreen()
 {
    PAINTSTRUCT pc;
+   RECT r = { 10, 10, 110, 110 };
    HDC dc = BeginPaint( g_globals.hWndMain, &pc );
 
    StretchDIBits(
@@ -336,6 +337,35 @@ internal void RenderScreen()
       &( g_globals.bmpInfo ),
       DIB_RGB_COLORS, SRCCOPY
    );
+
+   SetTextColor( dc, 0x00FFFFFF );
+   SetBkMode( dc, TRANSPARENT );
+
+   if ( g_debugFlags.passableTiles )
+   {
+      DrawTextA( dc, "passable tiles", -1, &r, DT_SINGLELINE | DT_NOCLIP );
+      r.top += 16;
+   }
+   if ( g_debugFlags.encounterRates )
+   {
+      DrawTextA( dc, "encounter rates", -1, &r, DT_SINGLELINE | DT_NOCLIP );
+      r.top += 16;
+   }
+   if ( g_debugFlags.fastWalk )
+   {
+      DrawTextA( dc, "fast walk", -1, &r, DT_SINGLELINE | DT_NOCLIP );
+      r.top += 16;
+   }
+   if ( g_debugFlags.noEncounters )
+   {
+      DrawTextA( dc, "no encounters", -1, &r, DT_SINGLELINE | DT_NOCLIP );
+      r.top += 16;
+   }
+   if ( g_debugFlags.noClip )
+   {
+      DrawTextA( dc, "no clip", -1, &r, DT_SINGLELINE | DT_NOCLIP );
+      r.top += 16;
+   }
 
    EndPaint( g_globals.hWndMain, &pc );
 }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -93,6 +93,7 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    g_debugFlags.passableTiles = False;
    g_debugFlags.encounterRates = False;
    g_debugFlags.fastWalk = False;
+   g_debugFlags.noEncounters = False;
 
    InitButtonMap();
    InitBattleStartRects();
@@ -298,6 +299,9 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                break;
             case VK_DEBUG_FASTWALK:
                TOGGLE_BOOL( g_debugFlags.fastWalk );
+               break;
+            case VK_DEBUG_NOENCOUNTERS:
+               TOGGLE_BOOL( g_debugFlags.noEncounters );
                break;
          }
       }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -90,6 +90,8 @@ int CALLBACK WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
    g_globals.bmpInfo.bmiHeader.biBitCount = 32;
    g_globals.bmpInfo.bmiHeader.biCompression = BI_RGB;
 
+   g_globals.debugShowTilePassability = False;
+
    InitButtonMap();
    InitBattleStartRects();
    Game_Init( &( g_globals.game ) );
@@ -278,6 +280,12 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                Input_ButtonPressed( &( g_globals.game.input ), i );
                break;
             }
+         }
+
+         if ( keyCode == VK_DEBUG_TILEPASSABILITY && g_globals.game.state == GAMESTATE_MAP )
+         {
+            TOGGLE_BOOL( g_globals.debugShowTilePassability );
+            Game_RefreshMap( &( g_globals.game ) );
          }
       }
       else

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
@@ -3,6 +3,8 @@
 
 internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y );
 internal int8_t Screen_GetCharIndexFromChar( const char c );
+internal uint32_t Screen_GetBlendedPixelColor( uint8_t tile, uint16_t color16 );
+internal uint32_t Screen_LinearBlend( uint32_t source, uint32_t dest );
 
 internal uint32_t Convert565To32( uint16_t color )
 {
@@ -102,13 +104,12 @@ void Screen_DrawTileMap( Game_t* game )
                pixelPair = map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels[pixelCol + ( pixelRow * MAP_PACKED_TILE_SIZE )];
 
                paletteIndex = pixelPair >> 4;
-               color32 = Convert565To32( screen->mapPalette[paletteIndex] );
-               *bufferPos = color32;
+               *bufferPos = Screen_GetBlendedPixelColor( tile, screen->mapPalette[paletteIndex] );
                bufferPos++;
 
                paletteIndex = pixelPair & 0x0F;
                color32 = Convert565To32( screen->mapPalette[paletteIndex] );
-               *bufferPos = color32;
+               *bufferPos = Screen_GetBlendedPixelColor( tile, screen->mapPalette[paletteIndex] );
                bufferPos++;
             }
          }
@@ -245,7 +246,7 @@ void Screen_DrawMapSprites( Game_t* game )
 {
    uint8_t i, tileX, tileY, spriteIndex, pixelPair, paletteIndex;
    uint16_t tileIndex, color16, j, pixel, x, y;
-   uint32_t color32;
+   uint32_t color32, ti;
    Screen_t* screen = &( game->screen );
    TileMap_t* map = &( game->tileMap );
    uint32_t treasureFlag;
@@ -284,7 +285,8 @@ void Screen_DrawMapSprites( Game_t* game )
          {
             color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ) );
          }
-         color32 = Convert565To32( color16 );
+         ti = MIN_I( tileIndex, 299 );
+         color32 = Screen_GetBlendedPixelColor( game->tileMap.tiles[ti], color16 );
 
          *bufferPos = color32;
          pixel++;
@@ -296,7 +298,8 @@ void Screen_DrawMapSprites( Game_t* game )
          {
             color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ) );
          }
-         color32 = Convert565To32( color16 );
+         ti = MIN_I( tileIndex, 299 );
+         color32 = Screen_GetBlendedPixelColor( game->tileMap.tiles[ti], color16 );
 
          *bufferPos = color32;
          pixel++;
@@ -314,7 +317,7 @@ void Screen_DrawPlayer( Game_t* game )
 {
    uint8_t pixelPair, paletteIndex, skipLeft, skipTop, skipRight, skipBottom, curX, curY;
    uint16_t startByte = ( (uint8_t)( game->player.sprite.direction ) * SPRITE_FRAMES * SPRITE_TEXTURE_SIZE_BYTES ) + ( game->player.sprite.currentFrame * SPRITE_TEXTURE_SIZE_BYTES );
-   uint16_t color16, i, pixel, ux, uy;
+   uint16_t color16, i, pixel, ux, uy, tx, ty;
    uint32_t color32;
    Screen_t* screen = &( game->screen );
    float x = game->player.position.x + PLAYER_SPRITEOFFSET_X;
@@ -364,9 +367,16 @@ void Screen_DrawPlayer( Game_t* game )
          color16 = screen->mapPalette[paletteIndex];
          if ( color16 == TRANSPARENT_COLOR )
          {
-            color16 = Screen_GetTilePixelColor( game, ux + ( pixel % SPRITE_SIZE ), uy + ( pixel / SPRITE_SIZE ) );
+            tx = ux + ( pixel % SPRITE_SIZE );
+            ty = uy + ( pixel / SPRITE_SIZE );
+            color16 = Screen_GetTilePixelColor( game, tx, ty );
+            uint16_t tileIndex = ( ( ty / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( tx / MAP_TILE_SIZE );
+            color32 = Screen_GetBlendedPixelColor( game->tileMap.tiles[tileIndex], color16 );
          }
-         color32 = Convert565To32( color16 );
+         else
+         {
+            color32 = Convert565To32( color16 );
+         }
          *bufferPos = color32;
       }
 
@@ -380,9 +390,16 @@ void Screen_DrawPlayer( Game_t* game )
          color16 = screen->mapPalette[paletteIndex];
          if ( color16 == TRANSPARENT_COLOR )
          {
-            color16 = Screen_GetTilePixelColor( game, ux + ( pixel % SPRITE_SIZE ), uy + ( pixel / SPRITE_SIZE ) );
+            tx = ux + ( pixel % SPRITE_SIZE );
+            ty = uy + ( pixel / SPRITE_SIZE );
+            color16 = Screen_GetTilePixelColor( game, tx, ty );
+            uint16_t tileIndex = ( ( ty / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( tx / MAP_TILE_SIZE );
+            color32 = Screen_GetBlendedPixelColor( game->tileMap.tiles[tileIndex], color16 );
          }
-         color32 = Convert565To32( color16 );
+         else
+         {
+            color32 = Convert565To32( color16 );
+         }
          *bufferPos = color32;
       }
 
@@ -487,7 +504,7 @@ void Screen_WipeEnemy( Game_t* game, uint16_t x, uint16_t y )
 void Screen_WipeTileMapSection( Game_t* game, float x, float y, uint16_t w, uint16_t h )
 {
    uint16_t color16, ux, uy, row, col;
-   uint32_t color32;
+   uint32_t color32, ti;
    uint32_t* bufferPos;
 
    if ( x >= ( MAP_TILE_SIZE * MAP_TILES_X ) || y >= ( MAP_TILE_SIZE * MAP_TILES_Y ) ||
@@ -525,7 +542,9 @@ void Screen_WipeTileMapSection( Game_t* game, float x, float y, uint16_t w, uint
       for ( col = ux; col < ux + w; col++ )
       {
          color16 = Screen_GetTilePixelColor( game, col, row );
-         color32 = Convert565To32( color16 );
+         uint16_t tileIndex = ( ( row / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( col / MAP_TILE_SIZE );
+         ti = MIN_I( tileIndex, 299 );
+         color32 = Screen_GetBlendedPixelColor( game->tileMap.tiles[ti], color16 );
          *bufferPos = color32;
          bufferPos++;
       }
@@ -627,4 +646,42 @@ internal int8_t Screen_GetCharIndexFromChar( const char c )
          default: return -1;
       }
    }
+}
+
+internal uint32_t Screen_GetBlendedPixelColor( uint8_t tile, uint16_t color16 )
+{
+   Bool_t passable = GET_TILE_PASSABLE( tile );
+   uint32_t dest32 = Convert565To32( color16 );
+
+   if ( g_globals.debugShowTilePassability )
+   {
+      uint32_t overlay32 = passable ? 0xFF00FF00 : 0xFFFF0000;
+      dest32 = Screen_LinearBlend( overlay32, dest32 );
+   }
+   
+   return dest32;
+}
+
+internal uint32_t Screen_LinearBlend( uint32_t source, uint32_t dest )
+{
+   float A, R, G, B, sourceR, sourceG, sourceB, destR, destG, destB;
+
+   // dest = ( ( 1 - alpha ) * src ) + ( alpha * src )
+   A = 0.5f;
+   sourceR = (float)( ( source >> 16 ) & 0xFF );
+   sourceG = (float)( ( source >> 8 ) & 0xFF );
+   sourceB = (float)( source & 0xFF );
+
+   destR = (float)( ( dest >> 16 ) & 0xFF );
+   destG = (float)( ( dest >> 8 ) & 0xFF );
+   destB = (float)( dest & 0xFF );
+
+   R = ( ( 1.0f - A ) * destR ) + ( A * sourceR );
+   G = ( ( 1.0f - A ) * destG ) + ( A * sourceG );
+   B = ( ( 1.0f - A ) * destB ) + ( A * sourceB );
+
+   return ( 0xFF000000 |
+          ( (uint32_t)( R + 0.5f ) << 16 ) |
+          ( (uint32_t)( G + 0.5f ) << 8 ) |
+          (uint32_t)( B + 0.5f ) );
 }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
@@ -652,12 +652,12 @@ internal uint32_t Screen_GetBlendedPixelColor( Game_t* game, uint8_t tile, uint1
    Bool_t passable = GET_TILE_PASSABLE( tile );
    uint32_t dest = Convert565To32( color16 );
 
-   if ( g_globals.debugFlags & DEBUGMASK_TILEPASSABILITY )
+   if ( g_debugFlags.passableTiles )
    {
       overlay = passable ? 0xFF00FF00 : 0xFFFF0000;
       dest = Screen_LinearBlend( overlay, dest, 0.4f );
    }
-   else if ( g_globals.debugFlags & DEBUGMASK_ENCOUNTERRATE )
+   else if ( g_debugFlags.encounterRates )
    {
       tileTextureIndex = GET_TILE_TEXTURE_INDEX( tile );
       tileFlags = game->tileMap.tileTextures[MIN_I( tileTextureIndex, 15 )].flags;


### PR DESCRIPTION
## Overview

It was getting tedious remembering which debug flags to turn on and off, so this PR adds the ability to toggle them in real-time when using Visual Studio. It also adds a couple new ones, and shows on the screen which flags are currently active.

- press 1 to toggle the passable tiles overlay (only works in GAMESTATE_MAP), which highlights passable tiles in green and impassable tiles in red. Toggling this will turn off the encounter rate overlay.
- press 2 to toggle the encounter rate overlay (only works in GAMESTATE_MAP), which highlights tiles in different shades of red based on their encounter rate (darker red = higher rate). Toggling this will turn off the passable tiles overlay.
- press 3 to toggle fast-walk, which sets the player's speed to 96 at all times.
- press 4 to toggle encounters. When this is on, you'll never encounter an enemy.
- press 5 to toggle no-clip mode. When this is on, you can walk through un-passable tiles, but will still run into things like stairs, town/cave/castle entrances, and will still transition between tile maps.
- press 0 to turn off all debug flags. Note that this will only turn off the passable tiles and encounter rate overlays if you're in GAMESTATE_MAP.

NOTE: be careful with no-clip mode, because it is possible to end up on a tile map that doesn't actually exist. When that happens, the previous tile map will still be on the screen, but it won't be the one you're actually on. I was gonna fix that, but it didn't seem necessary, since no-clip is only for debugging.

## Bonus

I added a function (currently unused) to `win_main.c` that allows you to output all tile maps to BMP files in a specified directory. It was supposed to be just a one-off thing that I would delete later, but it seemed really useful, so I left it in there.