### PR TITLE
Bugfix: Item offsets

### DIFF
--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -180,15 +180,15 @@
 #define GET_ITEM_HERBCOUNT( x )              ( ( ( x ) >> 3 ) & 0x7 )
 #define GET_ITEM_WINGCOUNT( x )              ( ( ( x ) >> 6 ) & 0x7 )
 #define GET_ITEM_FAIRYWATERCOUNT( x )        ( ( ( x ) >> 9 ) & 0x7 )
-#define GET_ITEM_HASTABLET( x )              ( ( x ) >> 10 & 0x1 )
-#define GET_ITEM_HASSTONEOFSUNLIGHT( x )     ( ( x ) >> 11 & 0x1 )
+#define GET_ITEM_HASTABLET( x )              ( ( x ) >> 12 & 0x1 )
+#define GET_ITEM_HASSTONEOFSUNLIGHT( x )     ( ( x ) >> 13 & 0x1 )
 
 #define SET_ITEM_KEYCOUNT( x, c )            x |= ( ( c ) & 0x7 )
 #define SET_ITEM_HERBCOUNT( x, c )           x |= ( ( (uint32_t)( c ) & 0x7 ) << 3 )
 #define SET_ITEM_WINGCOUNT( x, c )           x |= ( ( (uint32_t)( c ) & 0x7 ) << 6 )
 #define SET_ITEM_FAIRYWATERCOUNT( x, c )     x |= ( ( (uint32_t)( c ) & 0x7 ) << 9 )
-#define SET_ITEM_HASTABLET( x, b )           x |= ( ( uint32_t )( b ) << 10 )
-#define SET_ITEM_HASSTONEOFSUNLIGHT( x, b )  x |= ( ( uint32_t )( b ) << 11 )
+#define SET_ITEM_HASTABLET( x, b )           x |= ( ( uint32_t )( b ) << 12 )
+#define SET_ITEM_HASSTONEOFSUNLIGHT( x, b )  x |= ( ( uint32_t )( b ) << 13 )
 
 typedef uint8_t Bool_t;
 #define True 1


### PR DESCRIPTION
Addressed card: #67 

## Overview

Long story short, I messed up some of the item macros. This resulted in a weird issue where if you have the Stone of Sunlight, then the map item menu shows you having the maximum amount of Fairy Waters. This PR fixes the issue.