### PR TITLE
Bugfix: Drawing the player on a boundary

### DIFF
--- a/DataGenerator/DataGenerator/Program.cs
+++ b/DataGenerator/DataGenerator/Program.cs
@@ -5,7 +5,7 @@ using System.Windows.Media.Imaging;
 using DataGenerator;
 using Newtonsoft.Json;
 
-var _mapPalette = new List<ushort>();
+var _palette = new List<ushort>();
 var _textTextureMap = new List<byte>();
 var _tileTextureMapBytes = new List<byte>();
 var _mapSpritesBytes = new List<byte>();
@@ -114,7 +114,7 @@ void LoadMapTileset( BitmapSource bitmap )
    {
       throw new Exception( "Trying to add too many map tile textures." );
    }
-   else if ( _mapPalette is null )
+   else if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, no idea how it happened." );
    }
@@ -124,7 +124,7 @@ void LoadMapTileset( BitmapSource bitmap )
       for ( int col = 0; col < bitmap.PixelWidth; col++ )
       {
          var pixelColor = GetPixelColor16( bitmap, col, row );
-         _tileTextureMapBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _mapPalette ) );
+         _tileTextureMapBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _palette ) );
       }
    }
 }
@@ -139,7 +139,7 @@ void LoadMapSprites( BitmapSource bitmap )
    {
       throw new Exception( "Trying to add too many map sprites." );
    }
-   else if ( _mapPalette is null )
+   else if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, no idea how it happened." );
    }
@@ -149,7 +149,7 @@ void LoadMapSprites( BitmapSource bitmap )
       for ( int col = 0; col < bitmap.PixelWidth; col++ )
       {
          var pixelColor = GetPixelColor16( bitmap, col, row );
-         _mapSpritesBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _mapPalette ) );
+         _mapSpritesBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _palette ) );
       }
    }
 }
@@ -160,7 +160,7 @@ void LoadPlayerSpriteTextureMap( BitmapSource bitmap )
    {
       throw new Exception( "Somehow the player sprite texture map is null, no idea how it happened." );
    }
-   else if ( _mapPalette is null )
+   else if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, no idea how it happened." );
    }
@@ -170,7 +170,7 @@ void LoadPlayerSpriteTextureMap( BitmapSource bitmap )
       for ( int col = 0; col < bitmap.PixelWidth; col++ )
       {
          var pixelColor = GetPixelColor16( bitmap, col, row );
-         _playerSpriteTextureMapBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _mapPalette ) );
+         _playerSpriteTextureMapBytes.Add( (byte)PaletteIndexFromColor( pixelColor, _palette ) );
       }
    }
 }
@@ -250,7 +250,7 @@ void LoadEnemies()
 
 string BuildMapPaletteOutputString()
 {
-   if ( _mapPalette is null )
+   if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, I have no idea what could have happened." );
    }
@@ -262,13 +262,13 @@ string BuildMapPaletteOutputString()
 
    for ( int i = 0; i < 16; i++ )
    {
-      if ( i < _mapPalette.Count )
+      if ( i < _palette.Count )
       {
-         outputString += string.Format( "      screen->mapPalette[{0}] = 0x{1};\n", i, _mapPalette[i].ToString( "X4" ) );
+         outputString += string.Format( "      screen->palette[{0}] = 0x{1};\n", i, _palette[i].ToString( "X4" ) );
       }
       else
       {
-         outputString += string.Format( "      screen->mapPalette[{0}] = 0x0000;\n", i );
+         outputString += string.Format( "      screen->palette[{0}] = 0x0000;\n", i );
       }
    }
 
@@ -280,7 +280,7 @@ string BuildMapPaletteOutputString()
 
 string BuildMapTileTexturesOutputString()
 {
-   if ( _mapPalette is null )
+   if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, I have no idea what could have happened." );
    }
@@ -378,7 +378,7 @@ string BuildMapTileTexturesOutputString()
 
 string BuildMapSpriteTexturesOutputString()
 {
-   if ( _mapPalette is null )
+   if ( _palette is null )
    {
       throw new Exception( "Somehow the map palette is null, I have no idea what could have happened." );
    }

--- a/FinalQuestino/data_loader.c
+++ b/FinalQuestino/data_loader.c
@@ -6,22 +6,22 @@ void Screen_LoadMapPalette( Screen_t* screen, uint8_t index )
 {
    if ( index == 0 )
    {
-      screen->mapPalette[0] = 0x9720;
-      screen->mapPalette[1] = 0x4521;
-      screen->mapPalette[2] = 0x0000;
-      screen->mapPalette[3] = 0xFEB3;
-      screen->mapPalette[4] = 0x7BEF;
-      screen->mapPalette[5] = 0x3AFE;
-      screen->mapPalette[6] = 0xFFFF;
-      screen->mapPalette[7] = 0xB5D6;
-      screen->mapPalette[8] = 0xDA60;
-      screen->mapPalette[9] = 0xFCE0;
-      screen->mapPalette[10] = 0xF81F;
-      screen->mapPalette[11] = 0x71E0;
-      screen->mapPalette[12] = 0x39FF;
-      screen->mapPalette[13] = 0xFDBC;
-      screen->mapPalette[14] = 0x0000;
-      screen->mapPalette[15] = 0x0000;
+      screen->palette[0] = 0x9720;
+      screen->palette[1] = 0x4521;
+      screen->palette[2] = 0x0000;
+      screen->palette[3] = 0xFEB3;
+      screen->palette[4] = 0x7BEF;
+      screen->palette[5] = 0x3AFE;
+      screen->palette[6] = 0xFFFF;
+      screen->palette[7] = 0xB5D6;
+      screen->palette[8] = 0xDA60;
+      screen->palette[9] = 0xFCE0;
+      screen->palette[10] = 0xF81F;
+      screen->palette[11] = 0x71E0;
+      screen->palette[12] = 0x39FF;
+      screen->palette[13] = 0xFDBC;
+      screen->palette[14] = 0x0000;
+      screen->palette[15] = 0x0000;
    }
 }
 

--- a/FinalQuestino/screen.h
+++ b/FinalQuestino/screen.h
@@ -112,7 +112,7 @@ typedef struct Screen_t
    uint8_t wrPinUnset;
    uint8_t rdPinUnset;
 
-   uint16_t mapPalette[16];
+   uint16_t palette[16];
    uint8_t textBitFields[TEXT_TILE_COUNT][8];
 
    uint8_t mapSpriteIndexCache;


### PR DESCRIPTION
Addresses issue: #66 

## Overview

This fixes two bugs:

- Sometimes the player is erased when collecting a treasure on the edge of the map.
- In Windows, the top of the player gets cut off when standing at the very edge of the map.

Turns out these were both related to sprite offsets. When standing at the edge of the map, it's possible for the sprite offset to cause the sprite's position to be off-screen, and since we use unsigned ints for almost everything, it was causing some overflow/underflow issues. This should hopefully fix everything, so the player is always drawn correctly.

Just one caveat: there's something weird in `Screen_GetTilePixelColor` (I left a TODO about it) where sometimes you need to adjust a pixel value by 1. I didn't look very far into it, because it seems to "just work" now, but it might be worth checking out later if we run into any more of these issues.