### PR TITLE
Revamped the map items menu

### DIFF
--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -67,7 +67,7 @@
 #define GAMESTATE_BATTLEATTACKRESULT         7
 #define GAMESTATE_BATTLERESULT               8
 #define GAMESTATE_BATTLECOLLECT              9
-#define GAMESTATE_MAPNOITEMSMESSAGE          10
+#define GAMESTATE_MAPITEMMESSAGE             10
 #define GAMESTATE_MAPMENUITEMS               11
 
 #define BUTTON_LEFT                          0
@@ -184,6 +184,13 @@
 #define GET_ITEM_FAIRYWATERCOUNT( x )        ( ( ( x ) >> 9 ) & 0x7 )
 #define GET_ITEM_HASTABLET( x )              ( ( x ) >> 12 & 0x1 )
 #define GET_ITEM_HASSTONEOFSUNLIGHT( x )     ( ( x ) >> 13 & 0x1 )
+
+#define GET_ITEM_COUNT( x )                  ( 0 + ( GET_ITEM_KEYCOUNT( x ) ? 1 : 0 ) + \
+                                                   ( GET_ITEM_HERBCOUNT( x ) ? 1 : 0 ) + \
+                                                   ( GET_ITEM_WINGCOUNT( x ) ? 1 : 0 ) + \
+                                                   ( GET_ITEM_FAIRYWATERCOUNT( x ) ? 1 : 0 ) + \
+                                                   ( GET_ITEM_HASTABLET( x ) ? 1 : 0 ) + \
+                                                   ( GET_ITEM_HASSTONEOFSUNLIGHT( x ) ? 1 : 0 ) )
 
 // TODO: keep an eye on these and make sure they actually go away when you use them
 #define SET_ITEM_KEYCOUNT( x, c )            ( x ) = ( ( ( x ) & 0xFFFFFFF8 ) | ( ( c ) & 0x7 ) )

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -199,7 +199,7 @@
 #define GET_ITEM_HASTOKEN( x )               ( ( x ) >> 19 & 0x1 )
 #define GET_ITEM_HASSPHEREOFLIGHT( x )       ( ( x ) >> 20 & 0x1 )
 
-#define GET_MAPITEM_COUNT( x )               ( 0 + \
+#define GET_MAPUSEABLEITEM_COUNT( x )        ( 0 + \
                                              ( GET_ITEM_KEYCOUNT( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_HERBCOUNT( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_WINGCOUNT( x ) ? 1 : 0 ) + \
@@ -209,12 +209,16 @@
                                              ( GET_ITEM_HASFAIRYFLUTE( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_HASGWAELYNSLOVE( x ) ? 1 : 0 ) )
 
-// TODO: keep an eye on these and make sure they actually go away when you use them
+#define GET_MAPNONUSEABLEITEM_COUNT( x )     ( 0 + \
+                                             ( GET_ITEM_HASSTONEOFSUNLIGHT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSTAFFOFRAIN( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASTOKEN( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSPHEREOFLIGHT( x ) ? 1 : 0 ) )
+
 #define SET_ITEM_KEYCOUNT( x, c )            ( x ) = ( ( ( x ) & 0xFFFFFFF8 ) | ( ( c ) & 0x7 ) )
 #define SET_ITEM_HERBCOUNT( x, c )           ( x ) = ( ( ( x ) & 0xFFFFFFC7 ) | ( (uint32_t)( c ) & 0x7 ) << 3 )
 #define SET_ITEM_WINGCOUNT( x, c )           ( x ) = ( ( ( x ) & 0xFFFFFE3F ) | ( (uint32_t)( c ) & 0x7 ) << 6 )
 #define SET_ITEM_FAIRYWATERCOUNT( x, c )     ( x ) = ( ( ( x ) & 0xFFFFF1FF ) | ( (uint32_t)( c ) & 0x7 ) << 9 )
-
 #define SET_ITEM_HASTABLET( x, b )           x |= ( ( uint32_t )( b ) << 12 )
 #define SET_ITEM_HASSTONEOFSUNLIGHT( x, b )  x |= ( ( uint32_t )( b ) << 13 )
 #define SET_ITEM_HASSTAFFOFRAIN( x, b )      x |= ( ( uint32_t )( b ) << 14 )

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -172,6 +172,13 @@
 #define ITEM_FAIRYWATER                      3
 #define ITEM_TABLET                          4
 #define ITEM_STONEOFSUNLIGHT                 5
+#define ITEM_STAFFOFRAIN                     6
+#define ITEM_RAINBOWDROP                     7
+#define ITEM_SILVERHARP                      8
+#define ITEM_FAIRYFLUTE                      9
+#define ITEM_GWAELYNSLOVE                    10
+#define ITEM_TOKEN                           11
+#define ITEM_SPHEREOFLIGHT                   12
 
 #define ITEM_MAXKEYS                         6
 #define ITEM_MAXHERBS                        7
@@ -184,13 +191,27 @@
 #define GET_ITEM_FAIRYWATERCOUNT( x )        ( ( ( x ) >> 9 ) & 0x7 )
 #define GET_ITEM_HASTABLET( x )              ( ( x ) >> 12 & 0x1 )
 #define GET_ITEM_HASSTONEOFSUNLIGHT( x )     ( ( x ) >> 13 & 0x1 )
+#define GET_ITEM_HASSTAFFOFRAIN( x )         ( ( x ) >> 14 & 0x1 )
+#define GET_ITEM_HASRAINBOWDROP( x )         ( ( x ) >> 15 & 0x1 )
+#define GET_ITEM_HASSILVERHARP( x )          ( ( x ) >> 16 & 0x1 )
+#define GET_ITEM_HASFAIRYFLUTE( x )          ( ( x ) >> 17 & 0x1 )
+#define GET_ITEM_HASGWAELYNSLOVE( x )        ( ( x ) >> 18 & 0x1 )
+#define GET_ITEM_HASTOKEN( x )               ( ( x ) >> 19 & 0x1 )
+#define GET_ITEM_HASSPHEREOFLIGHT( x )       ( ( x ) >> 20 & 0x1 )
 
-#define GET_ITEM_COUNT( x )                  ( 0 + ( GET_ITEM_KEYCOUNT( x ) ? 1 : 0 ) + \
-                                                   ( GET_ITEM_HERBCOUNT( x ) ? 1 : 0 ) + \
-                                                   ( GET_ITEM_WINGCOUNT( x ) ? 1 : 0 ) + \
-                                                   ( GET_ITEM_FAIRYWATERCOUNT( x ) ? 1 : 0 ) + \
-                                                   ( GET_ITEM_HASTABLET( x ) ? 1 : 0 ) + \
-                                                   ( GET_ITEM_HASSTONEOFSUNLIGHT( x ) ? 1 : 0 ) )
+#define GET_MAPITEM_COUNT( x )               ( 0 + \
+                                             ( GET_ITEM_KEYCOUNT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HERBCOUNT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_WINGCOUNT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_FAIRYWATERCOUNT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSTONEOFSUNLIGHT( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSTAFFOFRAIN( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASRAINBOWDROP( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSILVERHARP( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASFAIRYFLUTE( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASGWAELYNSLOVE( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASTOKEN( x ) ? 1 : 0 ) + \
+                                             ( GET_ITEM_HASSPHEREOFLIGHT( x ) ? 1 : 0 ) )
 
 // TODO: keep an eye on these and make sure they actually go away when you use them
 #define SET_ITEM_KEYCOUNT( x, c )            ( x ) = ( ( ( x ) & 0xFFFFFFF8 ) | ( ( c ) & 0x7 ) )
@@ -200,6 +221,13 @@
 
 #define SET_ITEM_HASTABLET( x, b )           x |= ( ( uint32_t )( b ) << 12 )
 #define SET_ITEM_HASSTONEOFSUNLIGHT( x, b )  x |= ( ( uint32_t )( b ) << 13 )
+#define SET_ITEM_HASSTAFFOFRAIN( x, b )      x |= ( ( uint32_t )( b ) << 14 )
+#define SET_ITEM_HASRAINBOWDROP( x, b )      x |= ( ( uint32_t )( b ) << 15 )
+#define SET_ITEM_HASSILVERHARP( x, b )       x |= ( ( uint32_t )( b ) << 16 )
+#define SET_ITEM_HASFAIRYFLUTE( x, b )       x |= ( ( uint32_t )( b ) << 17 )
+#define SET_ITEM_HASGWAELYNSLOVE( x, b )     x |= ( ( uint32_t )( b ) << 18 )
+#define SET_ITEM_HASTOKEN( x, b )            x |= ( ( uint32_t )( b ) << 19 )
+#define SET_ITEM_HASSPHEREOFLIGHT( x, b )    x |= ( ( uint32_t )( b ) << 20 )
 
 
 typedef uint8_t Bool_t;

--- a/FinalQuestino/common.h
+++ b/FinalQuestino/common.h
@@ -204,14 +204,10 @@
                                              ( GET_ITEM_HERBCOUNT( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_WINGCOUNT( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_FAIRYWATERCOUNT( x ) ? 1 : 0 ) + \
-                                             ( GET_ITEM_HASSTONEOFSUNLIGHT( x ) ? 1 : 0 ) + \
-                                             ( GET_ITEM_HASSTAFFOFRAIN( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_HASRAINBOWDROP( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_HASSILVERHARP( x ) ? 1 : 0 ) + \
                                              ( GET_ITEM_HASFAIRYFLUTE( x ) ? 1 : 0 ) + \
-                                             ( GET_ITEM_HASGWAELYNSLOVE( x ) ? 1 : 0 ) + \
-                                             ( GET_ITEM_HASTOKEN( x ) ? 1 : 0 ) + \
-                                             ( GET_ITEM_HASSPHEREOFLIGHT( x ) ? 1 : 0 ) )
+                                             ( GET_ITEM_HASGWAELYNSLOVE( x ) ? 1 : 0 ) )
 
 // TODO: keep an eye on these and make sure they actually go away when you use them
 #define SET_ITEM_KEYCOUNT( x, c )            ( x ) = ( ( ( x ) & 0xFFFFFFF8 ) | ( ( c ) & 0x7 ) )

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -148,13 +148,13 @@ void Game_WipeMessage( Game_t* game )
 
 void Game_ShowMapMenuMessage( Game_t* game, const char* message )
 {
-   Screen_DrawRect( &( game->screen ), 112, 144, 192, 48, DARKGRAY );
-   Screen_DrawWrappedText( &( game->screen ), message, 120, 152, 22, 10, DARKGRAY, WHITE );
+   Screen_DrawRect( &( game->screen ), 112, 128, 192, 48, DARKGRAY );
+   Screen_DrawWrappedText( &( game->screen ), message, 120, 136, 22, 10, DARKGRAY, WHITE );
 }
 
 void Game_WipeMapMenuMessage( Game_t* game )
 {
-   Screen_WipeTileMapSection( game, 112, 144, 192, 48, False );
+   Screen_WipeTileMapSection( game, 112, 128, 192, 48, False );
 }
 
 void Game_ShowMapQuickStats( Game_t* game )
@@ -401,8 +401,7 @@ void Game_UseMapItem( Game_t* game, uint8_t itemId )
       case ITEM_KEY:
          Game_OpenDoor( game );
          break;
-      case ITEM_TABLET:
-      case ITEM_STONEOFSUNLIGHT:
+      default:
          SPRINTF_P( msg, PSTR( STR_MAP_MAPITEMCANNOTBEUSED ) );
          Game_ShowMapMenuMessage( game, msg );
          game->state = GAMESTATE_MAPITEMMESSAGE;

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -422,11 +422,11 @@ internal void Game_OpenDoor( Game_t* game )
 
       if ( game->doorFlags & doorFlag )
       {
-         game->doorFlags ^= doorFlag;
-         SET_ITEM_KEYCOUNT( game->player.items, GET_ITEM_KEYCOUNT( game->player.items ) - 1 );
          Game_WipeMapQuickStats( game );
          Menu_Wipe( game, MENUINDEX_MAP );
          Menu_Wipe( game, MENUINDEX_MAPITEMS );
+         game->doorFlags ^= doorFlag;
+         SET_ITEM_KEYCOUNT( game->player.items, GET_ITEM_KEYCOUNT( game->player.items ) - 1 );
          Screen_WipeTileIndex( game, facingTileIndex, False );
          game->state = GAMESTATE_MAP;
          return;

--- a/FinalQuestino/game.c
+++ b/FinalQuestino/game.c
@@ -148,13 +148,13 @@ void Game_WipeMessage( Game_t* game )
 
 void Game_ShowMapMenuMessage( Game_t* game, const char* message )
 {
-   Screen_DrawRect( &( game->screen ), 112, 128, 192, 48, DARKGRAY );
-   Screen_DrawWrappedText( &( game->screen ), message, 120, 136, 22, 10, DARKGRAY, WHITE );
+   Screen_DrawRect( &( game->screen ), 112, 136, 160, 48, DARKGRAY );
+   Screen_DrawWrappedText( &( game->screen ), message, 120, 144, 18, 10, DARKGRAY, WHITE );
 }
 
 void Game_WipeMapMenuMessage( Game_t* game )
 {
-   Screen_WipeTileMapSection( game, 112, 128, 192, 48, False );
+   Screen_WipeTileMapSection( game, 112, 136, 160, 48, False );
 }
 
 void Game_ShowMapQuickStats( Game_t* game )
@@ -335,6 +335,8 @@ internal Bool_t Game_CollectTreasure( Game_t* game, uint32_t treasureFlag )
          SPRINTF_P( msg, collected ? PSTR( STR_TREASURE_ITEMCOLLECTED ) : PSTR( STR_TREASURE_ITEMDENIED ), itemStr );
          break;
       case 0x100:  // erdrick's cave
+         // TODO: this is the only item we don't show in any menus, instead we need to
+         // display a series of dialogs with the tablet's message
          collected = Player_CollectItem( &( game->player ), ITEM_TABLET );
          SPRINTF_P( itemStr, PSTR( STR_ITEM_ERDRICKSTABLET ) );
          SPRINTF_P( msg, collected ? PSTR( STR_TREASURE_ITEMCOLLECTED ) : PSTR( STR_TREASURE_ITEMDENIED ), itemStr );
@@ -375,7 +377,7 @@ void Game_MapItem( Game_t* game )
 {
    char msg[64];
 
-   if ( Player_GetMapItemCount( &( game->player ) ) )
+   if ( GET_MAPUSEABLEITEM_COUNT( game->player.items ) || GET_MAPNONUSEABLEITEM_COUNT( game->player.items ) )
    {
       Menu_DrawCarat( game );
       Menu_Load( game, MENUINDEX_MAPITEMS );

--- a/FinalQuestino/input.c
+++ b/FinalQuestino/input.c
@@ -141,7 +141,7 @@ void Input_Handle( Game_t* game )
          if ( Input_AnyButtonPressed( &( game->input ) ) )
          {
             Game_WipeMapMenuMessage( game );
-            game->state = GAMESTATE_MAPMENUITEMS;
+            game->state = game->menu.index == MENUINDEX_MAPITEMS ? GAMESTATE_MAPMENUITEMS : GAMESTATE_MAPMENU;
          }
          break;
    }

--- a/FinalQuestino/input.c
+++ b/FinalQuestino/input.c
@@ -137,11 +137,11 @@ void Input_Handle( Game_t* game )
             Battle_Done( game );
          }
          break;
-      case GAMESTATE_MAPNOITEMSMESSAGE:
+      case GAMESTATE_MAPITEMMESSAGE:
          if ( Input_AnyButtonPressed( &( game->input ) ) )
          {
             Game_WipeMapMenuMessage( game );
-            game->state = GAMESTATE_MAPMENU;
+            game->state = GAMESTATE_MAPMENUITEMS;
          }
          break;
    }

--- a/FinalQuestino/menu.c
+++ b/FinalQuestino/menu.c
@@ -1,9 +1,10 @@
 #include "game.h"
 #include "menu.h"
 
-internal void Menu_SetMapItemFlags( Game_t* game );
+internal void Menu_SetItemFlags( Game_t* game );
 internal void Menu_MapMenuSelect( Game_t* game );
 internal void Menu_BattleMainSelect( Game_t* game );
+internal void Menu_ItemSelect( Game_t* game );
 internal void Menu_DrawMapMenu( Game_t* game );
 internal void Menu_DrawBattleMainMenu( Game_t* game );
 internal void Menu_DrawMapItemsMenu( Game_t* game );
@@ -23,7 +24,7 @@ void Menu_Load( Game_t* game, uint8_t menuIndex )
          break;
       case MENUINDEX_MAPITEMS:
          game->menu.optionCount = Player_GetMapItemCount( &( game->player ) );
-         Menu_SetMapItemFlags( game );
+         Menu_SetItemFlags( game );
          break;
    }
 }
@@ -53,7 +54,7 @@ void Menu_Wipe( Game_t* game, uint8_t menuIndex )
    {
       case MENUINDEX_MAP: Screen_WipeTileMapSection( game, 16, 88, 76, 88, False ); break;
       case MENUINDEX_BATTLEMAIN: Screen_WipeTileMapSection( game, 16, 152, 76, 72, False ); break;
-      case MENUINDEX_MAPITEMS: Screen_WipeTileMapSection( game, 112, 88, 164, 48, False ); break;
+      case MENUINDEX_MAPITEMS: Screen_WipeTileMapSection( game, 112, 16, 164, ( 8 * GET_ITEM_COUNT( game->player.items ) ) + 16, False ); break;
    }
 }
 
@@ -91,7 +92,7 @@ void Menu_DrawCarat( Game_t* game )
    {
       case MENUINDEX_MAP: x = 20; y = 96; break;
       case MENUINDEX_BATTLEMAIN: x = 20; y = 160; break;
-      case MENUINDEX_MAPITEMS: x = 120; y = 96; lineHeight = 8; break;
+      case MENUINDEX_MAPITEMS: x = 120; y = 24; lineHeight = 8; break;
    }
 
    Screen_DrawText( &( game->screen ), STR_MENU_CARAT, x, y + ( lineHeight * game->menu.selectedOption ), DARKGRAY, WHITE );
@@ -105,7 +106,7 @@ void Menu_WipeCarat( Game_t* game )
    {
       case MENUINDEX_MAP: x = 20; y = 96; break;
       case MENUINDEX_BATTLEMAIN: x = 20; y = 160; break;
-      case MENUINDEX_MAPITEMS: x = 120; y = 96; lineHeight = 8; break;
+      case MENUINDEX_MAPITEMS: x = 120; y = 24; lineHeight = 8; break;
    }
 
    Screen_DrawText( &( game->screen ), STR_MENU_BLANKCARAT, x, y + ( lineHeight * game->menu.selectedOption ), DARKGRAY, WHITE );
@@ -150,33 +151,23 @@ void Menu_Select( Game_t* game )
    {
       case MENUINDEX_MAP: Menu_MapMenuSelect( game ); break;
       case MENUINDEX_BATTLEMAIN: Menu_BattleMainSelect( game ); break;
-      case MENUINDEX_MAPITEMS: Game_UseMapItem( game, ( game->menu.mapItemFlags >> ( game->menu.selectedOption * 2 ) ) & 0x3 ); break;
+      case MENUINDEX_MAPITEMS: Menu_ItemSelect( game ); break;
    }
 }
 
-internal void Menu_SetMapItemFlags( Game_t* game )
+internal void Menu_SetItemFlags( Game_t* game )
 {
    uint32_t items = game->player.items;
    uint8_t shift = 0;
 
-   if ( GET_ITEM_KEYCOUNT( items ) )
+   if ( game->menu.index == MENUINDEX_MAPITEMS )
    {
-      game->menu.mapItemFlags = ITEM_KEY;
-      shift += 2;
-   }
-   if ( GET_ITEM_HERBCOUNT( items ) )
-   {
-      game->menu.mapItemFlags |= ( ITEM_HERB << shift );
-      shift += 2;
-   }
-   if ( GET_ITEM_WINGCOUNT( items ) )
-   {
-      game->menu.mapItemFlags |= ( ITEM_WING << shift );
-      shift += 2;
-   }
-   if ( GET_ITEM_FAIRYWATERCOUNT( items ) )
-   {
-      game->menu.mapItemFlags |= ( ITEM_FAIRYWATER << shift );
+      if ( GET_ITEM_KEYCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_KEY << shift; shift += 4; }
+      if ( GET_ITEM_HERBCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_HERB << shift; shift += 4; }
+      if ( GET_ITEM_WINGCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_WING << shift; shift += 4; }
+      if ( GET_ITEM_FAIRYWATERCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_FAIRYWATER << shift; shift += 4; }
+      if ( GET_ITEM_HASTABLET( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_TABLET << shift; shift += 4; }
+      if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_STONEOFSUNLIGHT << shift; shift += 4; }
    }
 }
 
@@ -201,6 +192,12 @@ internal void Menu_BattleMainSelect( Game_t* game )
       case 2: Battle_Item( game ); break;
       case 3: Battle_Flee( game ); break;
    }
+}
+
+internal void Menu_ItemSelect( Game_t* game )
+{
+   uint8_t itemId = ( game->menu.itemFlags >> ( game->menu.selectedOption * 4 ) ) & 0xF;
+   Game_UseMapItem( game, itemId );
 }
 
 internal void Menu_DrawMapMenu( Game_t* game )
@@ -238,34 +235,45 @@ internal void Menu_DrawBattleMainMenu( Game_t* game )
 internal void Menu_DrawMapItemsMenu( Game_t* game )
 {
    char str[32];
-   uint16_t textY = 96;
+   uint16_t textY = 24;
+   uint32_t items = game->player.items;
 
-   Screen_DrawRect( &( game->screen ), 112, 88, 164, 48, DARKGRAY );
+   Screen_DrawRect( &( game->screen ), 112, 16, 164, ( 8 * GET_ITEM_COUNT( items ) ) + 16, DARKGRAY );
 
-   if ( GET_ITEM_KEYCOUNT( game->player.items ) )
+   if ( GET_ITEM_KEYCOUNT( items ) )
    {
-      SPRINTF_P( str, PSTR( STR_MENU_KEY ), GET_ITEM_KEYCOUNT( game->player.items ) );
+      SPRINTF_P( str, PSTR( STR_MENU_KEY ), GET_ITEM_KEYCOUNT( items ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }
-
-   if ( GET_ITEM_HERBCOUNT( game->player.items ) )
+   if ( GET_ITEM_HERBCOUNT( items ) )
    {
-      SPRINTF_P( str, PSTR( STR_MENU_HERB ), GET_ITEM_HERBCOUNT( game->player.items ) );
+      SPRINTF_P( str, PSTR( STR_MENU_HERB ), GET_ITEM_HERBCOUNT( items ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }
-
-   if ( GET_ITEM_WINGCOUNT( game->player.items ) )
+   if ( GET_ITEM_WINGCOUNT( items ) )
    {
-      SPRINTF_P( str, PSTR( STR_MENU_WING ), GET_ITEM_WINGCOUNT( game->player.items ) );
+      SPRINTF_P( str, PSTR( STR_MENU_WING ), GET_ITEM_WINGCOUNT( items ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }
-
-   if ( GET_ITEM_FAIRYWATERCOUNT( game->player.items ) )
+   if ( GET_ITEM_FAIRYWATERCOUNT( items ) )
    {
-      SPRINTF_P( str, PSTR( STR_MENU_FAIRYWATER ), GET_ITEM_FAIRYWATERCOUNT( game->player.items ) );
+      SPRINTF_P( str, PSTR( STR_MENU_FAIRYWATER ), GET_ITEM_FAIRYWATERCOUNT( items ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASTABLET( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_TABLET ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_STONEOFSUNLIGHT ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
    }
 }

--- a/FinalQuestino/menu.c
+++ b/FinalQuestino/menu.c
@@ -54,7 +54,7 @@ void Menu_Wipe( Game_t* game, uint8_t menuIndex )
    {
       case MENUINDEX_MAP: Screen_WipeTileMapSection( game, 16, 88, 76, 88, False ); break;
       case MENUINDEX_BATTLEMAIN: Screen_WipeTileMapSection( game, 16, 152, 76, 72, False ); break;
-      case MENUINDEX_MAPITEMS: Screen_WipeTileMapSection( game, 112, 16, 164, ( 8 * GET_ITEM_COUNT( game->player.items ) ) + 16, False ); break;
+      case MENUINDEX_MAPITEMS: Screen_WipeTileMapSection( game, 112, 16, 164, ( 8 * GET_MAPITEM_COUNT( game->player.items ) ) + 16, False ); break;
    }
 }
 
@@ -168,8 +168,14 @@ internal void Menu_SetItemFlags( Game_t* game )
       if ( GET_ITEM_HERBCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_HERB << shift; shift += 4; }
       if ( GET_ITEM_WINGCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_WING << shift; shift += 4; }
       if ( GET_ITEM_FAIRYWATERCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_FAIRYWATER << shift; shift += 4; }
-      if ( GET_ITEM_HASTABLET( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_TABLET << shift; shift += 4; }
       if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_STONEOFSUNLIGHT << shift; shift += 4; }
+      if ( GET_ITEM_HASSTAFFOFRAIN( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_STAFFOFRAIN << shift; shift += 4; }
+      if ( GET_ITEM_HASRAINBOWDROP( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_RAINBOWDROP << shift; shift += 4; }
+      if ( GET_ITEM_HASSILVERHARP( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_SILVERHARP << shift; shift += 4; }
+      if ( GET_ITEM_HASFAIRYFLUTE( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_FAIRYFLUTE << shift; shift += 4; }
+      if ( GET_ITEM_HASGWAELYNSLOVE( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_GWAELYNSLOVE << shift; shift += 4; }
+      if ( GET_ITEM_HASTOKEN( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_TOKEN << shift; shift += 4; }
+      if ( GET_ITEM_HASSPHEREOFLIGHT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_SPHEREOFLIGHT << shift; shift += 4; }
    }
 }
 
@@ -240,7 +246,7 @@ internal void Menu_DrawMapItemsMenu( Game_t* game )
    uint16_t textY = 24;
    uint32_t items = game->player.items;
 
-   Screen_DrawRect( &( game->screen ), 112, 16, 164, ( 8 * GET_ITEM_COUNT( items ) ) + 16, DARKGRAY );
+   Screen_DrawRect( &( game->screen ), 112, 16, 164, ( 8 * GET_MAPITEM_COUNT( items ) ) + 16, DARKGRAY );
 
    if ( GET_ITEM_KEYCOUNT( items ) )
    {
@@ -266,15 +272,51 @@ internal void Menu_DrawMapItemsMenu( Game_t* game )
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }
-   if ( GET_ITEM_HASTABLET( items ) )
-   {
-      SPRINTF_P( str, PSTR( STR_MENU_TABLET ) );
-      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
-      textY += 8;
-   }
    if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) )
    {
       SPRINTF_P( str, PSTR( STR_MENU_STONEOFSUNLIGHT ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASSTAFFOFRAIN( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_STAFFOFRAIN ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASRAINBOWDROP( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_RAINBOWDROP ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASSILVERHARP( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_SILVERHARP ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASFAIRYFLUTE( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_FAIRYFLUTE ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASGWAELYNSLOVE( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_GWAELYNSLOVE ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASTOKEN( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_TOKEN ) );
+      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
+      textY += 8;
+   }
+   if ( GET_ITEM_HASSPHEREOFLIGHT( items ) )
+   {
+      SPRINTF_P( str, PSTR( STR_MENU_SPHEREOFLIGHT ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }

--- a/FinalQuestino/menu.c
+++ b/FinalQuestino/menu.c
@@ -168,14 +168,10 @@ internal void Menu_SetItemFlags( Game_t* game )
       if ( GET_ITEM_HERBCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_HERB << shift; shift += 4; }
       if ( GET_ITEM_WINGCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_WING << shift; shift += 4; }
       if ( GET_ITEM_FAIRYWATERCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_FAIRYWATER << shift; shift += 4; }
-      if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_STONEOFSUNLIGHT << shift; shift += 4; }
-      if ( GET_ITEM_HASSTAFFOFRAIN( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_STAFFOFRAIN << shift; shift += 4; }
       if ( GET_ITEM_HASRAINBOWDROP( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_RAINBOWDROP << shift; shift += 4; }
       if ( GET_ITEM_HASSILVERHARP( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_SILVERHARP << shift; shift += 4; }
       if ( GET_ITEM_HASFAIRYFLUTE( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_FAIRYFLUTE << shift; shift += 4; }
-      if ( GET_ITEM_HASGWAELYNSLOVE( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_GWAELYNSLOVE << shift; shift += 4; }
-      if ( GET_ITEM_HASTOKEN( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_TOKEN << shift; shift += 4; }
-      if ( GET_ITEM_HASSPHEREOFLIGHT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_SPHEREOFLIGHT << shift; shift += 4; }
+      if ( GET_ITEM_HASGWAELYNSLOVE( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_GWAELYNSLOVE << shift; }
    }
 }
 
@@ -272,18 +268,6 @@ internal void Menu_DrawMapItemsMenu( Game_t* game )
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }
-   if ( GET_ITEM_HASSTONEOFSUNLIGHT( items ) )
-   {
-      SPRINTF_P( str, PSTR( STR_MENU_STONEOFSUNLIGHT ) );
-      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
-      textY += 8;
-   }
-   if ( GET_ITEM_HASSTAFFOFRAIN( items ) )
-   {
-      SPRINTF_P( str, PSTR( STR_MENU_STAFFOFRAIN ) );
-      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
-      textY += 8;
-   }
    if ( GET_ITEM_HASRAINBOWDROP( items ) )
    {
       SPRINTF_P( str, PSTR( STR_MENU_RAINBOWDROP ) );
@@ -305,18 +289,6 @@ internal void Menu_DrawMapItemsMenu( Game_t* game )
    if ( GET_ITEM_HASGWAELYNSLOVE( items ) )
    {
       SPRINTF_P( str, PSTR( STR_MENU_GWAELYNSLOVE ) );
-      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
-      textY += 8;
-   }
-   if ( GET_ITEM_HASTOKEN( items ) )
-   {
-      SPRINTF_P( str, PSTR( STR_MENU_TOKEN ) );
-      Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
-      textY += 8;
-   }
-   if ( GET_ITEM_HASSPHEREOFLIGHT( items ) )
-   {
-      SPRINTF_P( str, PSTR( STR_MENU_SPHEREOFLIGHT ) );
       Screen_DrawText( &( game->screen ), str, 136, textY, DARKGRAY, WHITE );
       textY += 8;
    }

--- a/FinalQuestino/menu.c
+++ b/FinalQuestino/menu.c
@@ -160,6 +160,8 @@ internal void Menu_SetItemFlags( Game_t* game )
    uint32_t items = game->player.items;
    uint8_t shift = 0;
 
+   game->menu.itemFlags = 0;
+
    if ( game->menu.index == MENUINDEX_MAPITEMS )
    {
       if ( GET_ITEM_KEYCOUNT( items ) ) { game->menu.itemFlags |= (uint64_t)ITEM_KEY << shift; shift += 4; }

--- a/FinalQuestino/menu.h
+++ b/FinalQuestino/menu.h
@@ -10,10 +10,9 @@ typedef struct Menu_t
    uint8_t index;
    uint8_t optionCount;
    uint8_t selectedOption;
+   uint64_t itemFlags;
    float caratSeconds;
    Bool_t showCarat;
-
-   uint8_t mapItemFlags;
 }
 Menu_t;
 

--- a/FinalQuestino/player.c
+++ b/FinalQuestino/player.c
@@ -143,8 +143,14 @@ uint8_t Player_GetMapItemCount( Player_t* player )
    if ( GET_ITEM_HERBCOUNT( player->items ) ) count++;
    if ( GET_ITEM_WINGCOUNT( player->items ) ) count++;
    if ( GET_ITEM_FAIRYWATERCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_HASTABLET( player->items ) ) count++;
    if ( GET_ITEM_HASSTONEOFSUNLIGHT( player->items ) ) count++;
+   if ( GET_ITEM_HASSTAFFOFRAIN( player->items ) ) count++;
+   if ( GET_ITEM_HASRAINBOWDROP( player->items ) ) count++;
+   if ( GET_ITEM_HASSILVERHARP( player->items ) ) count++;
+   if ( GET_ITEM_HASFAIRYFLUTE( player->items ) ) count++;
+   if ( GET_ITEM_HASGWAELYNSLOVE( player->items ) ) count++;
+   if ( GET_ITEM_HASTOKEN( player->items ) ) count++;
+   if ( GET_ITEM_HASSPHEREOFLIGHT( player->items ) ) count++;
 
    return count;
 }

--- a/FinalQuestino/player.c
+++ b/FinalQuestino/player.c
@@ -143,14 +143,10 @@ uint8_t Player_GetMapItemCount( Player_t* player )
    if ( GET_ITEM_HERBCOUNT( player->items ) ) count++;
    if ( GET_ITEM_WINGCOUNT( player->items ) ) count++;
    if ( GET_ITEM_FAIRYWATERCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_HASSTONEOFSUNLIGHT( player->items ) ) count++;
-   if ( GET_ITEM_HASSTAFFOFRAIN( player->items ) ) count++;
    if ( GET_ITEM_HASRAINBOWDROP( player->items ) ) count++;
    if ( GET_ITEM_HASSILVERHARP( player->items ) ) count++;
    if ( GET_ITEM_HASFAIRYFLUTE( player->items ) ) count++;
    if ( GET_ITEM_HASGWAELYNSLOVE( player->items ) ) count++;
-   if ( GET_ITEM_HASTOKEN( player->items ) ) count++;
-   if ( GET_ITEM_HASSPHEREOFLIGHT( player->items ) ) count++;
 
    return count;
 }

--- a/FinalQuestino/player.c
+++ b/FinalQuestino/player.c
@@ -134,19 +134,3 @@ Bool_t Player_CollectItem( Player_t* player, uint8_t item )
 
    return collected;
 }
-
-uint8_t Player_GetMapItemCount( Player_t* player )
-{
-   uint8_t count = 0;
-
-   if ( GET_ITEM_KEYCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_HERBCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_WINGCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_FAIRYWATERCOUNT( player->items ) ) count++;
-   if ( GET_ITEM_HASRAINBOWDROP( player->items ) ) count++;
-   if ( GET_ITEM_HASSILVERHARP( player->items ) ) count++;
-   if ( GET_ITEM_HASFAIRYFLUTE( player->items ) ) count++;
-   if ( GET_ITEM_HASGWAELYNSLOVE( player->items ) ) count++;
-
-   return count;
-}

--- a/FinalQuestino/player.c
+++ b/FinalQuestino/player.c
@@ -143,6 +143,8 @@ uint8_t Player_GetMapItemCount( Player_t* player )
    if ( GET_ITEM_HERBCOUNT( player->items ) ) count++;
    if ( GET_ITEM_WINGCOUNT( player->items ) ) count++;
    if ( GET_ITEM_FAIRYWATERCOUNT( player->items ) ) count++;
+   if ( GET_ITEM_HASTABLET( player->items ) ) count++;
+   if ( GET_ITEM_HASSTONEOFSUNLIGHT( player->items ) ) count++;
 
    return count;
 }

--- a/FinalQuestino/player.h
+++ b/FinalQuestino/player.h
@@ -42,7 +42,6 @@ uint8_t Player_GetLevel( Player_t* player );
 uint16_t Player_CollectGold( Player_t* player, uint16_t gold );
 uint16_t Player_CollectExperience( Player_t* player, uint16_t experience );
 Bool_t Player_CollectItem( Player_t* player, uint8_t item );
-uint8_t Player_GetMapItemCount( Player_t* player );
 
 // data_loader.c
 void Player_LoadSprite( Player_t* player );

--- a/FinalQuestino/strings.h
+++ b/FinalQuestino/strings.h
@@ -16,6 +16,8 @@
 #define STR_MENU_HERB                                       "Herb (%u)"
 #define STR_MENU_WING                                       "Chimaera wing (%u)"
 #define STR_MENU_FAIRYWATER                                 "Fairy water (%u)"
+#define STR_MENU_TABLET                                     "Erdrick's Tablet"
+#define STR_MENU_STONEOFSUNLIGHT                            "Stone of Sunlight"
 
 #define STR_MAP_QUICKSTATSHP                                "HP:%u"
 #define STR_MAP_QUICKSTATSMP                                "MP:%u"
@@ -29,7 +31,8 @@
 #define STR_MAP_STATUSAGILITY                               "Agl: %u"
 #define STR_MAP_STATUSEXP                                   "Exp: %u"
 #define STR_MAP_FOUNDNOTHING                                "You didn't find anything."
-#define STR_MAP_NOITEMS                                     "You don't have any items that can be used here."
+#define STR_MAP_NOMAPITEMS                                  "You don't have any items that can be used here."
+#define STR_MAP_MAPITEMCANNOTBEUSED                         "This item cannot be used here."
 #define STR_MAP_NODOOR                                      "There is no door here."
 
 #define STR_BATTLE_QUICKSTATSHP                             "HP:%u"

--- a/FinalQuestino/strings.h
+++ b/FinalQuestino/strings.h
@@ -18,6 +18,13 @@
 #define STR_MENU_FAIRYWATER                                 "Fairy water (%u)"
 #define STR_MENU_TABLET                                     "Erdrick's Tablet"
 #define STR_MENU_STONEOFSUNLIGHT                            "Stone of Sunlight"
+#define STR_MENU_STAFFOFRAIN                                "Staff of Rain"
+#define STR_MENU_RAINBOWDROP                                "Rainbow Drop"
+#define STR_MENU_SILVERHARP                                 "Silver Harp"
+#define STR_MENU_FAIRYFLUTE                                 "Fairy Flute"
+#define STR_MENU_GWAELYNSLOVE                               "Gwaelyn's Love"
+#define STR_MENU_TOKEN                                      "Erdrick's Token"
+#define STR_MENU_SPHEREOFLIGHT                              "Sphere of Light"
 
 #define STR_MAP_QUICKSTATSHP                                "HP:%u"
 #define STR_MAP_QUICKSTATSMP                                "MP:%u"
@@ -105,6 +112,13 @@
 #define STR_ITEM_FAIRYWATER                                 "fairy water"
 #define STR_ITEM_ERDRICKSTABLET                             "Erdrick's Tablet"
 #define STR_ITEM_THESTONEOFSUNLIGHT                         "the Stone of Sunlight"
+#define STR_ITEM_THESTAFFOFRAIN                             "the Staff of Rain"
+#define STR_ITEM_ARAINBOWDROP                               "a Rainbow Drop"
+#define STR_ITEM_THESILVERHARP                              "the Silver Harp"
+#define STR_ITEM_THEFAIRYFLUTE                              "the Fairy Flute"
+#define STR_ITEM_GWAELYNSLOVE                               "Gwaelyn's Love"
+#define STR_ITEM_TOKEN                                      "Erdrick's Token"
+#define STR_ITEM_THESPHEREOFLIGHT                           "the Sphere of Light"
 
 // we should never see this, but just in case
 #define STR_ITEM_ERR                                        "The chest is a lie!"

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_common.h
@@ -15,7 +15,7 @@
 #include "vector.h"
 
 #define STRING_SIZE_DEFAULT         1024
-#define GRAPHICS_SCALE              2.0f
+#define GRAPHICS_SCALE              3.0f
 
 #define VK_DEBUG_PASSABLETILES      0x31     // 1
 #define VK_DEBUG_ENCOUNTERRATES     0x32     // 2

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_main.c
@@ -342,7 +342,7 @@ internal void HandleKeyboardInput( uint32_t keyCode, LPARAM flags )
                Player_CollectGold( &( g_globals.game.player ), 500 );
                if ( g_globals.game.state == GAMESTATE_MAPMENU ||
                     g_globals.game.state == GAMESTATE_MAPMENUITEMS ||
-                    g_globals.game.state == GAMESTATE_MAPNOITEMSMESSAGE )
+                    g_globals.game.state == GAMESTATE_MAPITEMMESSAGE )
                {
                   Game_ShowMapQuickStats( &( g_globals.game ) );
                }

--- a/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
+++ b/FinalQuestinoWinDev/FinalQuestinoWinDev/win_screen.c
@@ -1,7 +1,27 @@
 #include "screen.h"
 #include "win_common.h"
 
-internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y, Bool_t includePlayer );
+#define PLAYER_BLITPIXEL() \
+   color16 = screen->palette[paletteIndex]; \
+   if ( color16 == TRANSPARENT_COLOR ) \
+   { \
+      tx = ux + ( pixel % SPRITE_SIZE ); \
+      ty = uy + ( pixel / SPRITE_SIZE ); \
+      color16 = Screen_GetTilePixelColor( game, tx, ty ); \
+      uint16_t tileIndex = ( ( ty / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( tx / MAP_TILE_SIZE ); \
+      color32 = Screen_GetBlendedPixelColor( game, game->tileMap.tiles[MIN_I( tileIndex, 299 )], color16 ); \
+   } \
+   else \
+   { \
+      color32 = Convert565To32( color16 ); \
+   } \
+   *bufferPos = color32; \
+   sx++; \
+   pixel++; \
+   bufferPos++
+
+internal void Screen_DrawPlayerSpriteSection( Game_t* game, uint8_t sx, uint8_t sy, uint8_t w, uint8_t h );
+internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y );
 internal int8_t Screen_GetCharIndexFromChar( const char c );
 internal uint32_t Screen_GetBlendedPixelColor( Game_t* game, uint8_t tile, uint16_t color16 );
 internal uint32_t Screen_LinearBlend( uint32_t source, uint32_t dest, float alpha );
@@ -292,7 +312,7 @@ void Screen_DrawMapSprites( Game_t* game )
          color16 = screen->palette[paletteIndex];
          if ( color16 == TRANSPARENT_COLOR )
          {
-            color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ), True );
+            color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ) );
          }
          color32 = Screen_GetBlendedPixelColor( game, game->tileMap.tiles[MIN_I( tileIndex, 299 )], color16 );
 
@@ -304,7 +324,7 @@ void Screen_DrawMapSprites( Game_t* game )
          color16 = screen->palette[paletteIndex];
          if ( color16 == TRANSPARENT_COLOR )
          {
-            color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ), True );
+            color16 = Screen_GetTilePixelColor( game, x + ( pixel % SPRITE_SIZE ), y + ( pixel / SPRITE_SIZE ) );
          }
          color32 = Screen_GetBlendedPixelColor( game, game->tileMap.tiles[MIN_I( tileIndex, 299 )], color16 );
 
@@ -320,110 +340,9 @@ void Screen_DrawMapSprites( Game_t* game )
    }
 }
 
-#define PLAYER_BLITPIXEL() \
-   color16 = screen->palette[paletteIndex]; \
-   if ( color16 == TRANSPARENT_COLOR ) \
-   { \
-      tx = ux + ( pixel % SPRITE_SIZE ); \
-      ty = uy + ( pixel / SPRITE_SIZE ); \
-      color16 = Screen_GetTilePixelColor( game, tx, ty, False ); \
-      uint16_t tileIndex = ( ( ty / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( tx / MAP_TILE_SIZE ); \
-      color32 = Screen_GetBlendedPixelColor( game, game->tileMap.tiles[MIN_I( tileIndex, 299 )], color16 ); \
-   } \
-   else \
-   { \
-      color32 = Convert565To32( color16 ); \
-   } \
-   *bufferPos = color32; \
-   sx++; \
-   pixel++; \
-   bufferPos++
-
 void Screen_DrawPlayer( Game_t* game )
 {
-   uint8_t pixelPair, paletteIndex, skipLeft, skipTop, skipRight, skipBottom, sx, sy;
-   uint16_t startByte;
-   uint16_t color16, b, pixel, ux, uy, tx, ty;
-   uint32_t color32;
-   Screen_t* screen = &( game->screen );
-   float x = game->player.position.x + PLAYER_SPRITEOFFSET_X;
-   float y = game->player.position.y + PLAYER_SPRITEOFFSET_Y;
-   uint32_t* bufferPos;
-
-   if ( x >= ( MAP_TILE_SIZE * MAP_TILES_X ) || y >= ( MAP_TILE_SIZE * MAP_TILES_Y ) || x + SPRITE_SIZE < 0 || y + SPRITE_SIZE < 0 )
-   {
-      return;
-   }
-
-   if ( x < 0 )
-   {
-      ux = 0;
-      skipLeft = (uint8_t)( -( x - NEGATIVE_CLAMP_THETA ) );
-      skipRight = 0;
-   }
-   else
-   {
-      ux = (uint16_t)x;
-      skipLeft = 0;
-      skipRight = ( ux + SPRITE_SIZE ) >= ( MAP_TILE_SIZE * MAP_TILES_X ) ? (uint8_t)( MAP_TILE_SIZE - ( ( MAP_TILE_SIZE * MAP_TILES_X ) - ux ) ) : 0;
-   }
-
-   if ( y < 0 )
-   {
-      uy = 0;
-      skipTop = (uint8_t)( -( y - NEGATIVE_CLAMP_THETA ) );
-      skipBottom = 0;
-   }
-   else
-   {
-      uy = (uint16_t)y;
-      skipTop = 0;
-      skipBottom = ( uy + SPRITE_SIZE ) >= ( MAP_TILE_SIZE * MAP_TILES_Y ) ? (uint8_t)( MAP_TILE_SIZE - ( ( MAP_TILE_SIZE * MAP_TILES_Y ) - uy ) ) : 0;
-   }
-
-   startByte = ( (uint8_t)( game->player.sprite.direction ) * SPRITE_FRAMES * SPRITE_TEXTURE_SIZE_BYTES )
-               + ( game->player.sprite.currentFrame * SPRITE_TEXTURE_SIZE_BYTES )
-               + ( skipLeft / 2 )
-               + ( skipTop * 8 );
-   bufferPos = g_globals.screenBuffer.memory + ( uy * SCREEN_WIDTH ) + ux;
-
-   for ( b = startByte, pixel = 0, sx = skipLeft, sy = skipTop; b < startByte + SPRITE_TEXTURE_SIZE_BYTES; b++ )
-   {
-      pixelPair = game->player.sprite.frameTextures[b];
-      paletteIndex = pixelPair >> 4;
-      PLAYER_BLITPIXEL();
-
-      if ( sx >= SPRITE_SIZE - skipRight )
-      {
-         sx = skipLeft;
-         pixel += skipRight + skipLeft;
-         b += ( skipRight / 2 ) + ( skipLeft / 2 );
-         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE ) + skipLeft + skipRight;
-         continue;
-      }
-
-      paletteIndex = pixelPair & 0x0F;
-      PLAYER_BLITPIXEL();
-
-      if ( sx >= SPRITE_SIZE )
-      {
-         sx = 0;
-         sy++;
-         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE );
-      }
-      else if ( sx >= SPRITE_SIZE - skipRight )
-      {
-         sx = skipLeft;
-         pixel += skipRight + skipLeft;
-         b += ( skipRight / 2 ) + ( skipLeft / 2 );
-         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE ) + skipLeft + skipRight;
-      }
-
-      if ( sy >= SPRITE_SIZE - skipBottom )
-      {
-         break;
-      }
-   }
+   Screen_DrawPlayerSpriteSection( game, 0, 0, SPRITE_SIZE, SPRITE_SIZE );
 }
 
 void Screen_WipePlayer( Game_t* game )
@@ -503,6 +422,7 @@ void Screen_WipeEnemy( Game_t* game, uint16_t x, uint16_t y )
 
 void Screen_WipeTileMapSection( Game_t* game, float x, float y, uint16_t w, uint16_t h, Bool_t wipePlayer )
 {
+   int16_t sx, sy, xOffset, yOffset, redrawX, redrawY, redrawW, redrawH;
    uint16_t color16, ux, uy, row, col;
    uint32_t color32;
    uint32_t* bufferPos;
@@ -541,7 +461,7 @@ void Screen_WipeTileMapSection( Game_t* game, float x, float y, uint16_t w, uint
    {
       for ( col = ux; col < ux + w; col++ )
       {
-         color16 = Screen_GetTilePixelColor( game, col, row, wipePlayer ? False : True ); 
+         color16 = Screen_GetTilePixelColor( game, col, row );
          uint16_t tileIndex = ( ( row / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( col / MAP_TILE_SIZE );
          color32 = Screen_GetBlendedPixelColor( game, game->tileMap.tiles[MIN_I( tileIndex, 299 )], color16 );
          *bufferPos = color32;
@@ -549,6 +469,44 @@ void Screen_WipeTileMapSection( Game_t* game, float x, float y, uint16_t w, uint
       }
 
       bufferPos += ( SCREEN_WIDTH - w );
+   }
+
+   if ( !wipePlayer )
+   {
+      sx = (int16_t)( game->player.position.x ) + PLAYER_SPRITEOFFSET_X;
+      sy = (int16_t)( game->player.position.y ) + PLAYER_SPRITEOFFSET_Y;
+
+      if ( sx <= ( x + w ) && ( sx + SPRITE_SIZE ) >= x && sy <= ( y + h ) && ( sy + SPRITE_SIZE ) > y )
+      {
+         xOffset = (int16_t)( sx - x );
+         yOffset = (int16_t)( sy - y );
+         redrawX = 0;
+         redrawY = 0;
+         redrawW = SPRITE_SIZE;
+         redrawH = SPRITE_SIZE;
+
+         if ( xOffset < 0 )
+         {
+            redrawX = -xOffset;
+            redrawW = SPRITE_SIZE - redrawX;
+         }
+         else if ( xOffset % SPRITE_SIZE != 0 )
+         {
+            redrawW = SPRITE_SIZE - ( xOffset % SPRITE_SIZE );
+         }
+
+         if ( yOffset < 0 )
+         {
+            redrawY = -yOffset;
+            redrawH = SPRITE_SIZE - redrawY;
+         }
+         else if ( yOffset % SPRITE_SIZE != 0 )
+         {
+            redrawH = SPRITE_SIZE - ( yOffset % SPRITE_SIZE );
+         }
+
+         Screen_DrawPlayerSpriteSection( game, (uint8_t)redrawX, (uint8_t)redrawY, (uint8_t)redrawW, (uint8_t)redrawH );
+      }
    }
 }
 
@@ -560,11 +518,109 @@ void Screen_WipeTileIndex( Game_t* game, uint16_t tileIndex, Bool_t wipePlayer )
    Screen_WipeTileMapSection( game, (float)x * MAP_TILE_SIZE, (float)y * MAP_TILE_SIZE, MAP_TILE_SIZE, MAP_TILE_SIZE, wipePlayer );
 }
 
-internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y, Bool_t includePlayer )
+internal void Screen_DrawPlayerSpriteSection( Game_t* game, uint8_t sx, uint8_t sy, uint8_t w, uint8_t h )
 {
-   uint8_t i, tileTextureIndex, spriteIndex, pixelPair, paletteIndex;
-   int16_t sx, sy, tx, ty;
-   uint16_t color, startByte;
+   uint8_t pixelPair, paletteIndex, skipLeft, skipTop, skipRight, skipBottom;
+   uint16_t startByte;
+   uint16_t color16, b, pixel, ux, uy, tx, ty;
+   uint32_t color32;
+   Screen_t* screen = &( game->screen );
+   float px = game->player.position.x + PLAYER_SPRITEOFFSET_X;
+   float py = game->player.position.y + PLAYER_SPRITEOFFSET_Y;
+   uint32_t* bufferPos;
+
+   if ( px >= ( MAP_TILE_SIZE * MAP_TILES_X ) || py >= ( MAP_TILE_SIZE * MAP_TILES_Y ) || px + SPRITE_SIZE < 0 || py + SPRITE_SIZE < 0 )
+   {
+      return;
+   }
+
+   if ( px < 0 )
+   {
+      ux = 0;
+      skipLeft = (uint8_t)( -( px - NEGATIVE_CLAMP_THETA ) );
+      if ( skipLeft > sx )
+      {
+         sx = skipLeft;
+         w -= ( skipLeft - sx );
+      }
+      skipRight = SPRITE_SIZE - ( sx + w );
+   }
+   else
+   {
+      ux = (uint16_t)px;
+      skipLeft = sx;
+      skipRight = ( ux + SPRITE_SIZE ) >= ( MAP_TILE_SIZE * MAP_TILES_X ) ? (uint8_t)( MAP_TILE_SIZE - ( ( MAP_TILE_SIZE * MAP_TILES_X ) - ux ) ) : 0;
+      w = MIN_I( sx + w, skipRight );
+   }
+
+   if ( py < 0 )
+   {
+      uy = 0;
+      skipTop = (uint8_t)( -( py - NEGATIVE_CLAMP_THETA ) );
+      if ( skipTop > sy )
+      {
+         sy = skipTop;
+         h -= ( skipTop - sy );
+      }
+      skipBottom = SPRITE_SIZE - ( sy + h );
+   }
+   else
+   {
+      uy = (uint16_t)py;
+      skipTop = 0;
+      skipBottom = ( uy + SPRITE_SIZE ) >= ( MAP_TILE_SIZE * MAP_TILES_Y ) ? (uint8_t)( MAP_TILE_SIZE - ( ( MAP_TILE_SIZE * MAP_TILES_Y ) - uy ) ) : 0;
+      h = MIN_I( sy + h, skipBottom );
+   }
+
+   startByte = ( (uint8_t)( game->player.sprite.direction ) * SPRITE_FRAMES * SPRITE_TEXTURE_SIZE_BYTES )
+      + ( game->player.sprite.currentFrame * SPRITE_TEXTURE_SIZE_BYTES )
+      + ( skipLeft / 2 )
+      + ( skipTop * 8 );
+   bufferPos = g_globals.screenBuffer.memory + ( uy * SCREEN_WIDTH ) + ux;
+
+   for ( b = startByte, pixel = 0, sx = skipLeft, sy = skipTop; b < startByte + SPRITE_TEXTURE_SIZE_BYTES; b++ )
+   {
+      pixelPair = game->player.sprite.frameTextures[b];
+      paletteIndex = pixelPair >> 4;
+      PLAYER_BLITPIXEL();
+
+      if ( sx >= SPRITE_SIZE - skipRight )
+      {
+         sx = skipLeft;
+         pixel += skipRight + skipLeft;
+         b += ( skipRight / 2 ) + ( skipLeft / 2 );
+         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE ) + skipLeft + skipRight;
+         continue;
+      }
+
+      paletteIndex = pixelPair & 0x0F;
+      PLAYER_BLITPIXEL();
+
+      if ( sx >= SPRITE_SIZE )
+      {
+         sx = 0;
+         sy++;
+         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE );
+      }
+      else if ( sx >= SPRITE_SIZE - skipRight )
+      {
+         sx = skipLeft;
+         pixel += skipRight + skipLeft;
+         b += ( skipRight / 2 ) + ( skipLeft / 2 );
+         bufferPos += ( SCREEN_WIDTH - SPRITE_SIZE ) + skipLeft + skipRight;
+      }
+
+      if ( sy >= SPRITE_SIZE - skipBottom )
+      {
+         break;
+      }
+   }
+}
+
+internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y )
+{
+   uint8_t i, tileTextureIndex, spriteIndex;
+   uint16_t color;
    uint16_t tileIndex = ( ( y / MAP_TILE_SIZE ) * MAP_TILES_X ) + ( x / MAP_TILE_SIZE );
    TileMap_t* map = &( game->tileMap );
    uint8_t tile = map->tiles[tileIndex];
@@ -579,32 +635,6 @@ internal uint16_t Screen_GetTilePixelColor( Game_t* game, uint16_t x, uint16_t y
 #pragma warning( disable: 4047 )
    tileTexture = &( map->tileTextures[MIN_I( tileTextureIndex, 15 )].pixels );
 #pragma warning( default: 4047 )
-
-   if ( includePlayer )
-   {
-      sx = (int16_t)( game->player.position.x + PLAYER_SPRITEOFFSET_X );
-      sy = (int16_t)( game->player.position.y + PLAYER_SPRITEOFFSET_Y );
-
-      // TODO: if these values are negative, the player is drawn one pixel off, and
-      // I have no idea why. somehow this "fixes" it, but we should figure that out later.
-      if ( sy < 0 ) sy--;
-      if ( sx < 0 ) sx--;
-
-      if ( (int16_t)x >= sx && (int16_t)x < sx + SPRITE_SIZE && (int16_t)y >= sy && (int16_t)y < sy + SPRITE_SIZE )
-      {
-         startByte = ( (uint8_t)( game->player.sprite.direction ) * SPRITE_FRAMES * SPRITE_TEXTURE_SIZE_BYTES ) + ( game->player.sprite.currentFrame * SPRITE_TEXTURE_SIZE_BYTES );
-         tx = ( (int16_t)x - sx ) % SPRITE_SIZE;
-         ty = (int16_t)y - sy;
-         pixelPair = game->player.sprite.frameTextures[startByte + ( ty * ( SPRITE_SIZE / 2 ) ) + ( tx / 2 )];
-         paletteIndex = ( tx % 2 ) == 0 ? pixelPair >> 4 : pixelPair & 0x0F;
-         color = screen->palette[paletteIndex];
-
-         if ( color != TRANSPARENT_COLOR )
-         {
-            return color;
-         }
-      }
-   }
 
    // check if this pixel is on a treasure that has already been collected, or a door that has already been opened
    if ( !( treasureFlag && !( game->treasureFlags & treasureFlag ) ) && !( doorFlag && !( game->doorFlags & doorFlag ) ) )


### PR DESCRIPTION
## Overview

This started as a way of showing special items that can't be used on the map items menu, but ballooned into something else (as usual). I wound up optimizing the way we re-draw the player after wiping a section of the map (it's still not quite right, I think there are problems on the Arduino side with being one pixel off in some cases), and now we allow selection of useable items in the map items menu, and we'll show but not allow selecting non-useable items.